### PR TITLE
Devel 2024.10.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ install/
 deps/
 tests/__pycache__/
 *.csv
+__pycache__/

--- a/cmake/DRVInclude.cmake
+++ b/cmake/DRVInclude.cmake
@@ -148,7 +148,7 @@ function (drv_add_run_target run_target executable cpexecutable)
       COMMAND
       mkdir -p $<TARGET_PROPERTY:${run_target},SST_RUN_DIR> &&
       cd $<TARGET_PROPERTY:${run_target},SST_RUN_DIR> &&
-      PYTHONPATH=${DRV_SOURCE_DIR}/py:${DRV_SOURCE_DIR}/tests
+      PYTHONPATH=${DRV_SOURCE_DIR}/py::${DRV_SOURCE_DIR}/model
       $<TARGET_FILE:SST::SST> # the simulator
       $<TARGET_PROPERTY:${run_target},SST_SIM_OPTIONS> # options for the simulator
       $<TARGET_PROPERTY:${run_target},DRV_MODEL> # the model to simulate
@@ -196,7 +196,7 @@ function (drvx_add_run_target_with_command_processor run_target executable cpexe
     set_target_properties(
       ${run_target}
       PROPERTIES
-      DRV_MODEL ${DRV_SOURCE_DIR}/tests/PANDOHammerDrvX.py 
+      DRV_MODEL ${DRV_SOURCE_DIR}/model/drvx.py
       )
   endif()
 endfunction()
@@ -220,7 +220,7 @@ function (drvr_add_run_target_with_command_processor run_target rvexecutable cpe
     set_target_properties(
       ${run_target}
       PROPERTIES
-      DRV_MODEL ${DRV_SOURCE_DIR}/tests/PANDOHammerDrvR.py
+      DRV_MODEL ${DRV_SOURCE_DIR}/model/drvr.py
       )
     add_dependencies(${run_target} ${rvexecutable})
   endif()

--- a/cmake/DRVInclude.cmake
+++ b/cmake/DRVInclude.cmake
@@ -104,6 +104,13 @@ function (drvx_target_compile_options)
   endif()
 endfunction()
 
+# target compile options for a drvx target
+function (drvx_target_compile_options)
+  if (NOT DEFINED ARCH_RV64)
+    target_compile_options(${ARGV})
+  endif()
+endfunction()
+
 # creates a drv run target
 # ${run_target} should be the name of the target to create
 # ${executable} should be a target created with drv(x|r)_add_executable

--- a/cmake/DRVInclude.cmake
+++ b/cmake/DRVInclude.cmake
@@ -289,6 +289,19 @@ function (drvr_add_disassemble_target dis_target executable)
   endif()
 endfunction()
 
+# create a drvr disassembly target
+function (drvr_add_disassemble_target dis_target executable)
+  if (NOT DEFINED ARCH_RV64)
+    set(objdump ${GNU_RISCV_TOOLCHAIN_PREFIX}/bin/riscv64-unknown-elfpandodrvsim-objdump)
+    set(objdump_flags -D)
+    add_custom_target(${dis_target}
+      COMMAND ${objdump} ${objdump_flags} $<TARGET_FILE:${executable}> | tee $<TARGET_FILE:${executable}>.dis
+      DEPENDS ${executable}
+      VERBATIM
+      )
+  endif()
+endfunction()
+
 # creates a drvr executable target
 function (drvr_add_executable name)
   set(sources ${ARGN})

--- a/drvr/CMakeLists.txt
+++ b/drvr/CMakeLists.txt
@@ -97,8 +97,9 @@ drvr_test_with_pandohammer(gups gups.cpp)
 drvr_test_compile_options(gups -DTHREAD_UPDATES=4 -DTABLE_SIZE=${gups_table_size})
 drvr_test_build_properties(gups
   PROPERTIES
-  DRV_BUILD_CORE_THREADS 2
-  DRV_BUILD_POD_CORES 2
+  DRV_BUILD_CORE_THREADS 1
+  DRV_BUILD_POD_CORES 1
+  DRV_MODEL_OPTIONS --pxn-dram-banks=8
   )
 
 
@@ -136,7 +137,11 @@ drvr_test_with_pandohammer(print_int print_int.c)
 
 # puts
 drvr_test_with_pandohammer(puts puts.c)
-
+drvr_set_build_target_properties(drvr_puts
+  PROPERTIES
+  DRV_BUILD_POD_CORES 2
+  DRV_BUILD_CORE_THREADS 1
+  )
 # read
 drvr_test_with_pandohammer(read read.c)
 drvr_test_inputs(read read.txt)

--- a/drvx/CMakeLists.txt
+++ b/drvx/CMakeLists.txt
@@ -114,13 +114,14 @@ if (NOT DEFINED ARCH_RV64)
   drvx_test(gups) # more of a microbenchmark than a test
   drvx_test(gups_multi_node) # more of a microbenchmark than a test
 
-  math(EXPR gups_table_size "1 << 21")
+  math(EXPR gups_table_size "1 << 26")
   math(EXPR gups_thread_updates "1<<10")
   drvx_set_run_target_properties(
     drvx-run-gups
     PROPERTIES
     DRV_MODEL_POD_CORES 2
-    DRV_MODEL_PXN_PODS 4
+    DRV_MODEL_PXN_PODS 1
+    DRV_MODEL_OPTIONS "--pod-l2sp-banks=1 --pxn-dram-banks=4"
     DRV_APPLICATION_ARGV "${gups_table_size} ${gups_thread_updates}"
     )
   drvx_set_run_target_properties(
@@ -137,7 +138,7 @@ if (NOT DEFINED ARCH_RV64)
     PROPERTIES
     DRV_MODEL_POD_CORES 1
     DRV_MODEL_CORE_THREADS 1
-    DRV_APPLICATION_ARGV "1000 0"
+    DRV_APPLICATION_ARGV "1000 64"
     )
 
   add_custom_target(drvx-run-all

--- a/drvx/CMakeLists.txt
+++ b/drvx/CMakeLists.txt
@@ -131,6 +131,14 @@ if (NOT DEFINED ARCH_RV64)
     )
   drvx_test(stream)
 
+  drvx_test(stride)
+  drvx_set_run_target_properties(
+    drvx-run-stride
+    PROPERTIES
+    DRV_MODEL_POD_CORES 1
+    DRV_MODEL_CORE_THREADS 1
+    DRV_APPLICATION_ARGV "1000 0"
+    )
 
   add_custom_target(drvx-run-all
     DEPENDS "${DRVX_TESTS}"

--- a/drvx/CMakeLists.txt
+++ b/drvx/CMakeLists.txt
@@ -119,6 +119,8 @@ if (NOT DEFINED ARCH_RV64)
   drvx_set_run_target_properties(
     drvx-run-gups
     PROPERTIES
+    DRV_MODEL_POD_CORES 2
+    DRV_MODEL_PXN_PODS 4
     DRV_APPLICATION_ARGV "${gups_table_size} ${gups_thread_updates}"
     )
   drvx_set_run_target_properties(

--- a/drvx/stride.cpp
+++ b/drvx/stride.cpp
@@ -1,0 +1,18 @@
+#include <DrvAPI.hpp>
+
+using namespace DrvAPI;
+
+int StrideMain(int argc, char *argv[])
+{
+    int n = atoi(argv[1]);
+    int s = atoi(argv[2]);
+    long sum = 0;
+    printf("n = %d, s = %d\n", n, s);
+    pointer<long> v = myAbsoluteDRAMBase();
+    for (int i = 0, j = 0; i < n; i++, j+=s) {
+        DrvAPI::read<long>(v + j);
+    }
+    return sum;
+}
+
+declare_drv_api_main(StrideMain);

--- a/element/DrvStdMemory.cpp
+++ b/element/DrvStdMemory.cpp
@@ -97,7 +97,9 @@ DrvStdMemory::DrvStdMemory(SST::ComponentId_t id, SST::Params& params, DrvCore *
              core->getClockTC(),
              new SST::Interfaces::StandardMem::Handler<DrvStdMemory>(this, &DrvStdMemory::handleEvent));        
     }
-    DrvAPI::DrvAPIAddress mmio_start = core_->decoder().this_cores_absolute_ctrl_base();
+    DrvAPI::DrvAPIAddress mmio_start = params.find<DrvAPI::DrvAPIAddress>("memory_region_start", 0);
+    DrvAPI::DrvAPIAddress mmio_size  = params.find<DrvAPI::DrvAPIAddress>("memory_region_size", 0x1000);
+    output_.verbose(CALL_INFO, 0, 10, "Setting memory-mapped region to start at 0x%" PRIx64 " and size 0x%" PRIx64 "\n", mmio_start, mmio_size);
     mem_->setMemoryMappedAddressRegion(mmio_start, 0x1000);
 }
 

--- a/element/DrvStdMemory.hpp
+++ b/element/DrvStdMemory.hpp
@@ -88,6 +88,11 @@ public:
         SST::Drv::DrvMemory
     )
 
+    // memory mapped region
+    SST_ELI_DOCUMENT_PARAMS(
+        {"memory_region_start", "start of memory mapped region", "0"},
+        {"memory_region_size",  "size of memory mapped region", "4192"},
+    )
     // register subcomponent slots
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
         {"memory", "Memory component", "SST::Interfaces::StandardMem"}

--- a/element/SSTRISCVCore.cpp
+++ b/element/SSTRISCVCore.cpp
@@ -158,6 +158,17 @@ DrvAPI::DrvAPIAddressInfo RISCVCore::decodeAddress(uint64_t addr) const {
     return address_decoder_.decode(addr);
 }
 
+DrvAPI::DrvAPIAddress RISCVCore::l1spBase() const {
+    DrvAPI::DrvAPIAddressInfo info;
+    info.set_absolute(true)
+        .set_core(core_)
+        .set_pod(pod_)
+        .set_pxn(pxn_)
+        .set_l1sp()
+        .set_offset(0);
+    return address_decoder_.encode(info);
+}
+
 /* load program segment */
 void RISCVCore::loadProgramSegment(Elf64_Phdr* phdr) {
     using Write = Interfaces::StandardMem::Write;

--- a/element/SSTRISCVCore.hpp
+++ b/element/SSTRISCVCore.hpp
@@ -371,6 +371,12 @@ public:
      */
     DrvAPI::DrvAPIAddressInfo decodeAddress(uint64_t addr) const;
 
+
+    /**
+     * get the top of this l1sp's address
+     */
+    DrvAPI::DrvAPIAddress l1spBase() const;
+
     /**
      * is local l1sp for purpose of stats
      */

--- a/element/SSTRISCVSimulator.cpp
+++ b/element/SSTRISCVSimulator.cpp
@@ -412,6 +412,9 @@ uint64_t RISCVSimulator::visitCSRRWUnderMask(RISCVHart &hart, uint64_t csr, uint
     case CSR_MPXNDRAMSIZE: // read-only
         rval = core_->sys().pxnDRAMSize();
         break;
+    case CSR_L1SPBASE: // read-only
+        rval = core_->l1spBase();
+        break;
     case CSR_SLEEP: // write-only
         core_->putHartToSleep(shart, wval);
         break;

--- a/element/SSTRISCVSimulator.hpp
+++ b/element/SSTRISCVSimulator.hpp
@@ -128,6 +128,7 @@ private:
     static constexpr uint64_t CSR_CYCLE   = 0xC00;
 
     static constexpr uint64_t CSR_SLEEP = 0x7A5; // sleep for x cycles
+    static constexpr uint64_t CSR_L1SPBASE = 0x7A6; // get the absolute top of this cores L1 scratchpad
 private:
 
     /**

--- a/model/Makefile
+++ b/model/Makefile
@@ -1,0 +1,5 @@
+SST := $(HOME)/work/AGILE/devel/install/bin/sst
+
+.PHONY: run
+run: test.py
+	PYTHONPATH=$(HOME)/work/AGILE/devel/drv/py $(SST) test.py

--- a/model/cmdline.py
+++ b/model/cmdline.py
@@ -1,0 +1,51 @@
+import argparse
+
+def parse_args():
+    print("Parsing arguments")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("program", help="program to run")
+    parser.add_argument("argv", nargs=argparse.REMAINDER, help="arguments to program")
+    parser.add_argument("--verbose", type=int, default=0, help="verbosity of core")
+    parser.add_argument("--dram-access-time", type=str, default="100ns", help="latency of DRAM (only valid if using the latency based model)")
+    parser.add_argument("--dram-backend", type=str, default="simple", choices=['simple', 'ramulator','dramsim3'], help="backend timing model for DRAM")
+    parser.add_argument("--dram-backend-config", type=str, default="/root/sst-ramulator-src/configs/hbm4-pando-config.cfg",
+                        help="backend timing model configuration for DRAM")
+    parser.add_argument("--debug-init", action="store_true", help="enable debug of init")
+    parser.add_argument("--debug-memory", action="store_true", help="enable memory debug")
+    parser.add_argument("--debug-requests", action="store_true", help="enable debug of requests")
+    parser.add_argument("--debug-responses", action="store_true", help="enable debug of responses")
+    parser.add_argument("--debug-syscalls", action="store_true", help="enable debug of syscalls")
+    parser.add_argument("--debug-clock", action="store_true", help="enable debug of clock ticks")
+    parser.add_argument("--debug-mmio", action="store_true", help="enable debug of mmio requests to the core")
+    parser.add_argument("--verbose-memory", type=int, default=0, help="verbosity of memory")
+    parser.add_argument("--pod-cores", type=int, default=8, help="number of cores per pod")
+    parser.add_argument("--pxn-pods", type=int, default=1, help="number of pods")
+    parser.add_argument("--num-pxn", type=int, default=1, help="number of pxns")
+    parser.add_argument("--core-threads", type=int, default=16, help="number of threads per core")
+    parser.add_argument("--core-clock", type=str, default="1GHz", help="clock frequency of cores")
+    parser.add_argument("--core-max-idle", type=int, default=1, help="max idle time of cores")
+    parser.add_argument("--core-l1sp-size", type=int, default=4*1024, help="size of l1sp per core")
+
+    parser.add_argument("--pod-l2sp-banks", type=int, default=8, help="number of l2sp banks per pod")
+    parser.add_argument("--pod-l2sp-interleave", type=int, default=64, help="interleave size of l2sp addresses (defaults to no  interleaving)")
+    parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help="size of l2sp per pod (max {} bytes)".format(1024*1024))
+    
+    parser.add_argument("--pxn-dram-banks", type=int, default=1, help="number of dram banks per pxn")
+    parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
+    parser.add_argument("--pxn-dram-interleave", type=int, default=64, help="interleave size of dram addresses (defaults to no  interleaving)")
+    
+    parser.add_argument("--with-command-processor", type=str, default="",
+                        help="Command processor program to run. Defaults to empty string, in which no command processor will be included in the model.")
+    parser.add_argument("--cp-verbose", type=int, default=0, help="verbosity of command processor")
+    parser.add_argument("--cp-verbose-init", action="store_true", help="command processor enable debug of init")
+    parser.add_argument("--cp-verbose-requests", action="store_true", help="command processor enable debug of requests")
+    parser.add_argument("--cp-verbose-responses", action="store_true", help="command processor enable debug of responses")
+    parser.add_argument("--drvx-stack-in-l1sp", action="store_true", help="use l1sp backing storage as stack")
+    parser.add_argument("--drvr-isa-test", action="store_true", help="Running an ISA test")
+    parser.add_argument("--test-name", type=str, default="", help="Name of the test")
+    parser.add_argument("--core-stats", action="store_true", help="enable core statistics")
+    parser.add_argument("--stats-load-level", type=int, default=0, help="load level for statistics")
+    parser.add_argument("--trace-remote-pxn-memory", action="store_true", help="trace remote pxn memory accesses")
+
+    arguments = parser.parse_args()
+    return arguments

--- a/model/cmdline.py
+++ b/model/cmdline.py
@@ -26,13 +26,15 @@ def parse_args():
     parser.add_argument("--core-max-idle", type=int, default=1, help="max idle time of cores")
     parser.add_argument("--core-l1sp-size", type=int, default=4*1024, help="size of l1sp per core")
 
-    parser.add_argument("--pod-l2sp-banks", type=int, default=8, help="number of l2sp banks per pod")
-    parser.add_argument("--pod-l2sp-interleave", type=int, default=64, help="interleave size of l2sp addresses (defaults to no  interleaving)")
+    parser.add_argument("--pod-l2sp-banks", type=int, default=1, help="number of l2sp banks per pod")
+    parser.add_argument("--pod-l2sp-interleave", type=int, default=0, help="interleave size of l2sp addresses (defaults to no  interleaving)")
     parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help="size of l2sp per pod (max {} bytes)".format(1024*1024))
     
     parser.add_argument("--pxn-dram-banks", type=int, default=1, help="number of dram banks per pxn")
     parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
     parser.add_argument("--pxn-dram-interleave", type=int, default=64, help="interleave size of dram addresses (defaults to no  interleaving)")
+
+    parser.add_argument("--without-pxn-dram-cache", action="store_true", help="disable dram cache")
     
     parser.add_argument("--with-command-processor", type=str, default="",
                         help="Command processor program to run. Defaults to empty string, in which no command processor will be included in the model.")

--- a/model/cmdline.py
+++ b/model/cmdline.py
@@ -6,7 +6,7 @@ def parse_args():
     parser.add_argument("program", help="program to run")
     parser.add_argument("argv", nargs=argparse.REMAINDER, help="arguments to program")
     parser.add_argument("--verbose", type=int, default=0, help="verbosity of core")
-    parser.add_argument("--dram-access-time", type=str, default="100ns", help="latency of DRAM (only valid if using the latency based model)")
+    parser.add_argument("--dram-access-time", type=str, default="70ns", help="latency of DRAM (only valid if using the latency based model)")
     parser.add_argument("--dram-backend", type=str, default="simple", choices=['simple', 'ramulator','dramsim3'], help="backend timing model for DRAM")
     parser.add_argument("--dram-backend-config", type=str, default="/root/sst-ramulator-src/configs/hbm4-pando-config.cfg",
                         help="backend timing model configuration for DRAM")
@@ -27,10 +27,10 @@ def parse_args():
     parser.add_argument("--core-l1sp-size", type=int, default=4*1024, help="size of l1sp per core")
 
     parser.add_argument("--pod-l2sp-banks", type=int, default=1, help="number of l2sp banks per pod")
-    parser.add_argument("--pod-l2sp-interleave", type=int, default=0, help="interleave size of l2sp addresses (defaults to no  interleaving)")
+    parser.add_argument("--pod-l2sp-interleave", type=int, default=64, help="interleave size of l2sp addresses (defaults to no  interleaving)")
     parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help="size of l2sp per pod (max {} bytes)".format(1024*1024))
     
-    parser.add_argument("--pxn-dram-banks", type=int, default=1, help="number of dram banks per pxn")
+    parser.add_argument("--pxn-dram-banks", type=int, default=4, help="number of dram banks per pxn")
     parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
     parser.add_argument("--pxn-dram-interleave", type=int, default=64, help="interleave size of dram addresses (defaults to no  interleaving)")
 

--- a/model/cmdline.py
+++ b/model/cmdline.py
@@ -24,15 +24,15 @@ def parse_args():
     parser.add_argument("--core-threads", type=int, default=16, help="number of threads per core")
     parser.add_argument("--core-clock", type=str, default="1GHz", help="clock frequency of cores")
     parser.add_argument("--core-max-idle", type=int, default=1, help="max idle time of cores")
-    parser.add_argument("--core-l1sp-size", type=int, default=4*1024, help="size of l1sp per core")
+    parser.add_argument("--core-l1sp-size", type=int, default=128*1024, help="size of l1sp per core")
 
     parser.add_argument("--pod-l2sp-banks", type=int, default=1, help="number of l2sp banks per pod")
-    parser.add_argument("--pod-l2sp-interleave", type=int, default=64, help="interleave size of l2sp addresses (defaults to no  interleaving)")
+    parser.add_argument("--pod-l2sp-interleave", type=int, default=0, help="interleave size of l2sp addresses (defaults to no  interleaving)")
     parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help="size of l2sp per pod (max {} bytes)".format(1024*1024))
     
-    parser.add_argument("--pxn-dram-banks", type=int, default=4, help="number of dram banks per pxn")
+    parser.add_argument("--pxn-dram-banks", type=int, default=1, help="number of dram banks per pxn")
     parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
-    parser.add_argument("--pxn-dram-interleave", type=int, default=64, help="interleave size of dram addresses (defaults to no  interleaving)")
+    parser.add_argument("--pxn-dram-interleave", type=int, default=0, help="interleave size of dram addresses (defaults to no  interleaving)")
 
     parser.add_argument("--without-pxn-dram-cache", action="store_true", help="disable dram cache")
     

--- a/model/cmdline.py
+++ b/model/cmdline.py
@@ -28,10 +28,10 @@ def parse_args():
 
     parser.add_argument("--pod-l2sp-banks", type=int, default=1, help="number of l2sp banks per pod")
     parser.add_argument("--pod-l2sp-interleave", type=int, default=0, help="interleave size of l2sp addresses (defaults to no  interleaving)")
-    parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help="size of l2sp per pod (max {} bytes)".format(1024*1024))
+    parser.add_argument("--pod-l2sp-size", type=int, default=1024*1024, help=f"size of l2sp per pod (max {2**20} bytes)")
     
     parser.add_argument("--pxn-dram-banks", type=int, default=1, help="number of dram banks per pxn")
-    parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
+    parser.add_argument("--pxn-dram-size", type=int, default=2*(1024**3), help=f"size of main memory per pxn (max {8*(2**30)} bytes)")
     parser.add_argument("--pxn-dram-interleave", type=int, default=0, help="interleave size of dram addresses (defaults to no  interleaving)")
 
     parser.add_argument("--without-pxn-dram-cache", action="store_true", help="disable dram cache")

--- a/model/compute.py
+++ b/model/compute.py
@@ -143,8 +143,10 @@ class XCoreBuilder(CoreBuilder):
         rbldr = CoreCtrlAddressBuilder(addressmap, 0x1000)
         if not self.is_host:
             start, *_ = rbldr(system_builder.pxn.id,system_builder.pxn.pod.id,self.id)
+            size = 0x1000
         else:
             start = 0
+            size = 0
 
         core.memory \
             = core.component.setSubComponent("memory", "Drv.DrvStdMemory")
@@ -154,7 +156,7 @@ class XCoreBuilder(CoreBuilder):
             "verbose_requests" : self.debug.debug_requests,
             "verbose_responses" : self.debug.debug_responses,
             "memory_region_start" : start,
-            "memory_region_size" : 0x1000,
+            "memory_region_size" : 0,
         })
 
         core.memory_interface \

--- a/model/compute.py
+++ b/model/compute.py
@@ -1,6 +1,6 @@
 import sst
 from memory import L1SPBuilder
-from addressmap import L1SPAddressBuilder
+from addressmap import L1SPAddressBuilder, CoreCtrlAddressBuilder
 #from tile import Tile, TileBuilder
 
 class CoreDebug(object):
@@ -65,20 +65,8 @@ class CoreBuilder(object):
         self.id = 0
         self.debug = CoreDebug()
         self.network_bw = "24GB/s"
-
-    @property
-    def destinations(self):
-        """
-        groups this core can talk to
-        """
-        return "0,1,2"
-
-    @property
-    def group(self):
-        """
-        network group
-        """
-        return "0"
+        self.destinations = "0,1,2"
+        self.group = "1"
 
     def build(self, system_builder, name):
         """
@@ -145,11 +133,19 @@ class XCoreBuilder(CoreBuilder):
     """
     def __init__(self):
         super().__init__()
+        self.is_host = False
 
     def build_core_network_interface(self, system_builder, core):
         """
         Build the network interface for the core
         """
+        addressmap = system_builder.addressmap()
+        rbldr = CoreCtrlAddressBuilder(addressmap, 0x1000)
+        if not self.is_host:
+            start, *_ = rbldr(system_builder.pxn.id,system_builder.pxn.pod.id,self.id)
+        else:
+            start = 0
+
         core.memory \
             = core.component.setSubComponent("memory", "Drv.DrvStdMemory")
         core.memory.addParams({
@@ -157,6 +153,8 @@ class XCoreBuilder(CoreBuilder):
             "verbose_init" : self.debug.debug_init,
             "verbose_requests" : self.debug.debug_requests,
             "verbose_responses" : self.debug.debug_responses,
+            "memory_region_start" : start,
+            "memory_region_size" : 0x1000,
         })
 
         core.memory_interface \
@@ -343,14 +341,6 @@ class ComputeBuilder(object):
     def ports(self):
         # core + l1sp + network
         return 3
-
-    @property
-    def group(self):
-        return "0"
-
-    @property
-    def destinations(self):
-        return "0,1,2"
 
     def build(self, system_builder, name):
         """

--- a/model/compute.py
+++ b/model/compute.py
@@ -188,6 +188,7 @@ class XCoreBuilder(CoreBuilder):
         """
         return {
             "clock" : self.clock,
+            "max_idle" : 2,
             "threads" : self.threads,
             "executable" : self.executable,
             "argv" : self.argv,

--- a/model/compute.py
+++ b/model/compute.py
@@ -370,13 +370,19 @@ class ComputeBuilder(object):
         compute.router.setSubComponent("topology", "merlin.singlerouter")
 
         # build the core
+        # we're modeling a direct link from the core to it's memory
+        # the scratchpad latency is in its 'access_time' parameter
+        local_latency = "0ps"
+        # 1 cycle latency from the network into the tile
+        network_latency = "1ns"
+
         self.core.id = self.id
         compute.core = self.core.build(system_builder, self.core_name(name))
         nwif, port  = compute.core.network_interface()
         link = sst.Link("{}_to_{}".format(self.router_name(name), self.core_name(name)))
         link.connect(
-            (nwif, port, "1ns"),
-            (compute.router, self.core_port(), "1ns")
+            (nwif, port, local_latency),
+            (compute.router, self.core_port(), local_latency)
         )
 
         # build the l1sp
@@ -384,8 +390,8 @@ class ComputeBuilder(object):
         nwif, port = compute.l1sp.network_interface()
         link = sst.Link("{}_to_{}".format(self.router_name(name), self.l1sp_name(name)))
         link.connect(
-            (compute.router, self.l1sp_port(), "1ns"),
-            (nwif, port, "1ns")
+            (compute.router, self.l1sp_port(), local_latency),
+            (nwif, port, local_latency)
         )
 
         # build the network bridge
@@ -396,8 +402,8 @@ class ComputeBuilder(object):
         })
         link = sst.Link("{}_to_{}".format(self.router_name(name), self.bridge_name(name)))
         link.connect(
-            (compute.router, self.network_port(), "1ns"),
-            (compute.bridge, "network0", "1ns"),
+            (compute.router, self.network_port(), network_latency),
+            (compute.bridge, "network0", network_latency)
         )
         return compute
 

--- a/model/compute.py
+++ b/model/compute.py
@@ -255,7 +255,7 @@ class RCoreBuilder(CoreBuilder):
         thread_stack_bytes = thread_stack_words * 8
         # build a string of stack pointers
         # to pass a parameter to the core
-        sp_v = ["{} {}".format(i, stack_base + ((i+1)*thread_stack_bytes) - 8) for i in range(self.threads)]
+        sp_v = [f"{i} {stack_base + ((i+1)*thread_stack_bytes) - 8}" for i in range(self.threads)]
         sp_str = "[" + ", ".join(sp_v) + "]"
         p["sp"] = sp_str
         return p
@@ -311,25 +311,25 @@ class ComputeBuilder(object):
         """
         Returns the router name
         """
-        return "{}_router".format(name)
+        return f"{name}_router"
 
     def core_name(self, name):
         """
         Returns the core name
         """
-        return "{}_core".format(name)
+        return f"{name}_core"
 
     def l1sp_name(self, name):
         """
         Returns the l1sp name
         """
-        return "{}_l1sp".format(name)
+        return f"{name}_l1sp"
 
     def bridge_name(self, name):
         """
         Returns the bridge name
         """
-        return "{}_bridge".format(name)
+        return f"{name}_bridge"
 
     def core_port(self):
         return "port0"
@@ -379,7 +379,7 @@ class ComputeBuilder(object):
         self.core.id = self.id
         compute.core = self.core.build(system_builder, self.core_name(name))
         nwif, port  = compute.core.network_interface()
-        link = sst.Link("{}_to_{}".format(self.router_name(name), self.core_name(name)))
+        link = sst.Link(f"{self.router_name(name)}_to_{self.core_name(name)}")
         link.connect(
             (nwif, port, local_latency),
             (compute.router, self.core_port(), local_latency)
@@ -388,7 +388,7 @@ class ComputeBuilder(object):
         # build the l1sp
         compute.l1sp = self.l1sp.build(system_builder, self.l1sp_name(name))
         nwif, port = compute.l1sp.network_interface()
-        link = sst.Link("{}_to_{}".format(self.router_name(name), self.l1sp_name(name)))
+        link = sst.Link(f"{self.router_name(name)}_to_{self.l1sp_name(name)}")
         link.connect(
             (compute.router, self.l1sp_port(), local_latency),
             (nwif, port, local_latency)
@@ -400,7 +400,7 @@ class ComputeBuilder(object):
             "translator" : "memHierarchy.MemNetBridge",
             "network_bw" : self.network_bw,
         })
-        link = sst.Link("{}_to_{}".format(self.router_name(name), self.bridge_name(name)))
+        link = sst.Link(f"{self.router_name(name)}_to_{self.bridge_name(name)}")
         link.connect(
             (compute.router, self.network_port(), network_latency),
             (compute.bridge, "network0", network_latency)

--- a/model/compute.py
+++ b/model/compute.py
@@ -64,7 +64,7 @@ class CoreBuilder(object):
     def __init__(self):
         self.id = 0
         self.debug = CoreDebug()
-        self.network_bw = "1GB/s"
+        self.network_bw = "24GB/s"
 
     @property
     def destinations(self):
@@ -187,6 +187,7 @@ class XCoreBuilder(CoreBuilder):
         Get the core parameters
         """
         return {
+            "clock" : self.clock,
             "threads" : self.threads,
             "executable" : self.executable,
             "argv" : self.argv,
@@ -234,6 +235,7 @@ class RCoreBuilder(CoreBuilder):
         Get the core parameters
         """
         p = {
+            "clock" : self.clock,
             "num_harts" : self.threads,
             "program" : self.executable,
             "core" : self.id,
@@ -295,12 +297,13 @@ class ComputeBuilder(object):
         self.argv = []
         self.l1sp = L1SPBuilder()
         self.core = CoreBuilder()
-        self.xbar_bw = "1GB/s"
-        self.link_bw = "1GB/s"
-        self.network_bw = "1GB/s"
-        self.input_buf_size = "1KB"
-        self.output_buf_size = "1KB"
-        self.router_latency = "1ns"
+        self.xbar_bw = "24GB/s"
+        self.link_bw = "24GB/s"
+        self.network_bw = "24GB/s"
+        self.flit_size = "8B"
+        self.input_buf_size = "1024B"
+        self.output_buf_size = "1024B"
+        self.router_latency = "0ns"
         return
 
     def router_name(self, name):
@@ -364,11 +367,12 @@ class ComputeBuilder(object):
             # configuration parameters
             "xbar_bw" : self.xbar_bw,
             "link_bw" : self.link_bw,
-            "flit_size" : "8B",
+            "flit_size" : self.flit_size,
             "input_buf_size" : self.input_buf_size,
             "output_buf_size" : self.output_buf_size,
             "input_latency" : self.router_latency,
             "output_latency" : self.router_latency,
+            "num_vns" : 1,
         })
         compute.router.setSubComponent("topology", "merlin.singlerouter")
 

--- a/model/compute.py
+++ b/model/compute.py
@@ -1,0 +1,407 @@
+import sst
+from memory import L1SPBuilder
+from addressmap import L1SPAddressBuilder
+#from tile import Tile, TileBuilder
+
+class CoreDebug(object):
+    """
+    A class to hold the debug configuration for a core
+    """
+    def __init__(self):
+        self.debug_level = 0
+        self.debug_init = False
+        self.debug_clock = False
+        self.debug_requests = False
+        self.debug_responses = False
+        self.debug_loopback = False
+        self.debug_mmio = False
+        self.debug_memory = False
+        self.debug_syscalls = False
+        self.trace_remote_pxn = False
+        self.trace_remote_pxn_load = False
+        self.trace_remote_pxn_store = False
+        self.trace_remote_pxn_atomic = False
+        self.isa_test = False
+        self.test_name = ""
+
+    def to_dict(self):
+        return {
+            "verbose" : self.debug_level,
+            "debug_init" : self.debug_init,
+            "debug_clock" : self.debug_clock,
+            "debug_requests" : self.debug_requests,
+            "debug_loopback" : self.debug_loopback,
+            "debug_mmio" : self.debug_mmio,
+            "debug_memory" : self.debug_memory,
+            "debug_responses" : self.debug_responses,
+            "debug_syscalls" : self.debug_syscalls,
+            "trace_remote_pxn" : self.trace_remote_pxn,
+            "trace_remote_pxn_load" : self.trace_remote_pxn_load,
+            "trace_remote_pxn_store" : self.trace_remote_pxn_store,
+            "trace_remote_pxn_atomic" : self.trace_remote_pxn_atomic,
+            "isa_test" : self.isa_test,
+            "test_name" : self.test_name
+        }
+
+class Core(object):
+    """
+    A base class for a core
+    """
+    def __init__(self, name):
+        self.component = None
+        self.memory = None
+        self.memory_interface = None
+        self.memory_nic = None
+        self.name = name
+
+    def network_interface(self):
+        return (self.memory_nic, "port")
+
+class CoreBuilder(object):
+    """
+    A base class for a core builder
+    """
+    def __init__(self):
+        self.id = 0
+        self.debug = CoreDebug()
+        self.network_bw = "1GB/s"
+
+    @property
+    def destinations(self):
+        """
+        groups this core can talk to
+        """
+        return "0,1,2"
+
+    @property
+    def group(self):
+        """
+        network group
+        """
+        return "0"
+
+    def build(self, system_builder, name):
+        """
+        Build the core
+        """
+        core = Core(name)
+        core.component = sst.Component(core.name, self.core_model)
+        core.component.addParams(self.system_params(system_builder))
+        core.component.addParams(self.debug_params())
+        core.component.addParams(self.core_params(system_builder))
+        self.build_core_network_interface(system_builder, core)
+        return core
+
+    def system_params(self, system_builder):
+        """
+        Return the system parameters
+        """
+        return {
+            "sys_num_pxn" : system_builder.pxns,
+            "sys_pxn_pods" : system_builder.pxn.pods,
+            "sys_pod_cores" : system_builder.pxn.pod.cores,
+            "sys_core_threads" : system_builder.pxn.pod.compute.core.threads,
+            "sys_core_clock" : "1GHz",
+            "sys_core_l1sp_size" : system_builder.pxn.pod.compute.l1sp.size,
+            "sys_pxn_dram_size" : system_builder.pxn.dram_size,
+            "sys_pxn_dram_ports" : system_builder.pxn.dram_banks,
+            "sys_pxn_dram_interleave_size" : system_builder.pxn.dram_interleave,
+            "sys_pod_l2sp_size" : system_builder.pxn.pod.l2sp_size,
+            "sys_pod_l2sp_banks" : system_builder.pxn.pod.l2sp_banks,
+            "sys_pod_l2sp_interleave_size" : system_builder.pxn.pod.l2sp_interleave,
+            "sys_nw_flit_dwords" : 1, # todo; get this from the system flit size
+            "sys_nw_obuf_dwords" : 8, # todo: get this from... what is this used for?
+            "sys_cp_present" : system_builder.pxn.hostcore_present,
+        }
+
+    def debug_params(self):
+        """
+        Get the debug parameters
+        """
+        return self.debug.to_dict()
+
+    def build_core_network_interface(self, system_builder, core):
+        """
+        Build the network interface for the core
+        """
+        raise NotImplementedError("build_core_network_interface is not implemented")
+
+    @property
+    def core_model(self):
+        """
+        Get the core model
+        """
+        raise NotImplementedError("core_model() method not implemented")
+
+    def core_params(self, system_builder):
+        """
+        Get the core parameters
+        """
+        raise NotImplementedError("core_params() method not implemented")
+
+class XCoreBuilder(CoreBuilder):
+    """
+    Builds a DrvX core
+    """
+    def __init__(self):
+        super().__init__()
+
+    def build_core_network_interface(self, system_builder, core):
+        """
+        Build the network interface for the core
+        """
+        core.memory \
+            = core.component.setSubComponent("memory", "Drv.DrvStdMemory")
+        core.memory.addParams({
+            "verbose" : self.debug.debug_level,
+            "verbose_init" : self.debug.debug_init,
+            "verbose_requests" : self.debug.debug_requests,
+            "verbose_responses" : self.debug.debug_responses,
+        })
+
+        core.memory_interface \
+            = core.memory.setSubComponent("memory", "memHierarchy.standardInterface")
+        core.memory_interface.addParams({
+            "verbose" : self.debug.debug_level,
+        })
+
+        core.memory_nic \
+            = core.memory_interface.setSubComponent("memlink", "memHierarchy.MemNIC")
+        core.memory_nic.addParams({
+            "group" : self.group,
+            "network_bw" : self.network_bw,
+            "destinations" : self.destinations,
+            "verbose_level" : 0
+        })
+        return core
+
+    @property
+    def core_model(self):
+        """
+        Get the core model
+        """
+        return "Drv.DrvCore"
+
+    def core_params(self, system_builder):
+        """
+        Get the core parameters
+        """
+        return {
+            "threads" : self.threads,
+            "executable" : self.executable,
+            "argv" : self.argv,
+            "id" : self.id,
+            "pod" : system_builder.pxn.pod.id,
+            "pxn" : system_builder.pxn.id,
+        }
+
+class RCoreBuilder(CoreBuilder):
+    """
+    Builds a DrvR core
+    """
+    def __init__(self):
+        super().__init__()
+
+    def build_core_network_interface(self, system_builder, core):
+        """
+        Build the network interface for the core
+        """
+        core.memory_interface \
+            = core.component.setSubComponent("memory", "memHierarchy.standardInterface")
+        core.memory_interface.addParams({
+            "verbose" : self.debug.debug_level,
+        })
+
+        core.memory_nic \
+            = core.memory_interface.setSubComponent("memlink", "memHierarchy.MemNIC")
+        core.memory_nic.addParams({
+            "group" : self.group,
+            "network_bw" : self.network_bw,
+            "destinations" : self.destinations,
+            "verbose_level" : 0
+        })
+        return core
+
+    @property
+    def core_model(self):
+        """
+        Get the core model
+        """
+        return "Drv.RISCVCore"
+
+    def core_params(self, system_builder):
+        """
+        Get the core parameters
+        """
+        p = {
+            "num_harts" : self.threads,
+            "program" : self.executable,
+            "core" : self.id,
+            "release_reset" : 10000,
+            "pod" : system_builder.pxn.pod.id,
+            "pxn" : system_builder.pxn.id,
+        }
+        # set the stack pointer
+        addrmap = system_builder.addressmap()
+        addrangebuilder = L1SPAddressBuilder(addrmap, system_builder.pxn.pod.compute.l1sp.size)
+        addr_start, addr_stop, *_ = addrangebuilder(system_builder.pxn.id, system_builder.pxn.pod.id, self.id)
+        stack_base = addr_start
+        stack_bytes = addr_stop - addr_start + 1
+        stack_words = stack_bytes // 8
+        thread_stack_words = stack_words // self.threads
+        thread_stack_bytes = thread_stack_words * 8
+        # build a string of stack pointers
+        # to pass a parameter to the core
+        sp_v = ["{} {}".format(i, stack_base + ((i+1)*thread_stack_bytes) - 8) for i in range(self.threads)]
+        sp_str = "[" + ", ".join(sp_v) + "]"
+        p["sp"] = sp_str
+        return p
+
+class Compute(object):
+    """
+    A base class for a compute tile
+    """
+    def __init__(self, name):
+        """
+        Initialize the compute tile
+        """
+        self.router = None
+        self.core = None
+        self.l1sp = None
+        self.bridge = None
+        self.name = name
+        return
+
+    def network_interface(self):
+        """
+        Returns the network interface subcomponent and port name
+        (interface, portname) pair
+        """
+        return (self.bridge, "network1")
+
+
+class ComputeBuilder(object):
+    """
+    A base class for a compute tile builder
+    """
+    def __init__(self):
+        """
+        Initialize the compute tile builder
+        """
+        self.id = 0
+        self.clock = "1GHz"
+        self.threads = 1
+        self.executable = ""
+        self.argv = []
+        self.l1sp = L1SPBuilder()
+        self.core = CoreBuilder()
+        self.xbar_bw = "1GB/s"
+        self.link_bw = "1GB/s"
+        self.network_bw = "1GB/s"
+        self.input_buf_size = "1KB"
+        self.output_buf_size = "1KB"
+        self.router_latency = "1ns"
+        return
+
+    def router_name(self, name):
+        """
+        Returns the router name
+        """
+        return "{}_router".format(name)
+
+    def core_name(self, name):
+        """
+        Returns the core name
+        """
+        return "{}_core".format(name)
+
+    def l1sp_name(self, name):
+        """
+        Returns the l1sp name
+        """
+        return "{}_l1sp".format(name)
+
+    def bridge_name(self, name):
+        """
+        Returns the bridge name
+        """
+        return "{}_bridge".format(name)
+
+    def core_port(self):
+        return "port0"
+
+    def l1sp_port(self):
+        return "port1"
+
+    def network_port(self):
+        return "port2"
+
+    def ports(self):
+        # core + l1sp + network
+        return 3
+
+    @property
+    def group(self):
+        return "0"
+
+    @property
+    def destinations(self):
+        return "0,1,2"
+
+    def build(self, system_builder, name):
+        """
+        Build the compute tile
+        """
+        compute = Compute(name)
+
+        # build the router
+        compute.router = sst.Component(self.router_name(name), "merlin.hr_router")
+        compute.router.addParams({
+            # semantic parameters
+            "id" : 0,
+            "num_ports" : self.ports(),
+            "topology" : "merlin.singlerouter",
+            # configuration parameters
+            "xbar_bw" : self.xbar_bw,
+            "link_bw" : self.link_bw,
+            "flit_size" : "8B",
+            "input_buf_size" : self.input_buf_size,
+            "output_buf_size" : self.output_buf_size,
+            "input_latency" : self.router_latency,
+            "output_latency" : self.router_latency,
+        })
+        compute.router.setSubComponent("topology", "merlin.singlerouter")
+
+        # build the core
+        self.core.id = self.id
+        compute.core = self.core.build(system_builder, self.core_name(name))
+        nwif, port  = compute.core.network_interface()
+        link = sst.Link("{}_to_{}".format(self.router_name(name), self.core_name(name)))
+        link.connect(
+            (nwif, port, "1ns"),
+            (compute.router, self.core_port(), "1ns")
+        )
+
+        # build the l1sp
+        compute.l1sp = self.l1sp.build(system_builder, self.l1sp_name(name))
+        nwif, port = compute.l1sp.network_interface()
+        link = sst.Link("{}_to_{}".format(self.router_name(name), self.l1sp_name(name)))
+        link.connect(
+            (compute.router, self.l1sp_port(), "1ns"),
+            (nwif, port, "1ns")
+        )
+
+        # build the network bridge
+        compute.bridge = sst.Component(self.bridge_name(name), "merlin.Bridge")
+        compute.bridge.addParams({
+            "translator" : "memHierarchy.MemNetBridge",
+            "network_bw" : self.network_bw,
+        })
+        link = sst.Link("{}_to_{}".format(self.router_name(name), self.bridge_name(name)))
+        link.connect(
+            (compute.router, self.network_port(), "1ns"),
+            (compute.bridge, "network0", "1ns"),
+        )
+        return compute
+
+

--- a/model/drvr.py
+++ b/model/drvr.py
@@ -1,0 +1,12 @@
+from system import *
+from cmdline import parse_args
+from pandohammer import PANDOHammer
+import argparse
+
+pandohammer = PANDOHammer(parse_args(), core_builder = RCoreBuilder)
+
+# create the system
+print("Building system")
+pandohammer.build()
+
+print("Running simualation")

--- a/model/drvx.py
+++ b/model/drvx.py
@@ -1,0 +1,12 @@
+from system import *
+from cmdline import parse_args
+from pandohammer import PANDOHammer
+import argparse
+
+pandohammer = PANDOHammer(parse_args(), core_builder = XCoreBuilder)
+
+# create the system
+print("Building system")
+pandohammer.build()
+
+print("Running simualation")

--- a/model/memory.py
+++ b/model/memory.py
@@ -242,6 +242,17 @@ class DRAMBuilder(MemoryBuilder):
         return addrrangebuilder(system_builder.pxn.id, \
                                 system_builder.pxn.dram.id)
 
+    @property
+    def memory_controller_model(self):
+        if not self.is_coherent:
+            return "memHierarchy.MemController"
+
+        return "memHierarchy.CoherentMemController"
+
+    @property
+    def is_coherent(self):
+        raise NotImplementedError
+
     def build_dram(self, system_builder, name):
         """
         Build the DRAM memory tile
@@ -251,13 +262,14 @@ class DRAMBuilder(MemoryBuilder):
             = self.address_range(system_builder)
 
         dram.memctrl = sst.Component(self.memctrl_name(name),\
-                                     "memHierarchy.MemController")
+                                     self.memory_controller_model)
         dram.memctrl.addParams({
             "clock" : self.clock,
             "addr_range_start" : addr_start,
             "addr_range_end" : addr_stop,
             "interleave_size" : '{}B'.format(addr_interleave_size),
             "interleave_step" : '{}B'.format(addr_interleave_step),
+            "max_requests_per_cycle" : 1,
         })
 
         dram.backend = dram.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
@@ -269,6 +281,10 @@ class DRAMBuilder(MemoryBuilder):
 
         dram.cmdhandler = \
             dram.memctrl.setSubComponent("customCmdHandler", "Drv.DrvCmdMemHandler")
+        dram.cmdhandler.addParams({
+            "cache_line_size" : self.cache_line_size if self.is_coherent else 0,
+            "shootdowns" : "true" if self.is_coherent else "false",
+        })
 
         return dram
 
@@ -316,6 +332,10 @@ class NoCacheDRAMBuilder(DRAMBuilder):
         Create the DRAM memory tile
         """
         return NoCacheDRAM(name)
+
+    @property
+    def is_coherent(self):
+        return False
 
     def build(self, system_builder, name):
         dram = self.build_dram(system_builder, name)
@@ -378,6 +398,10 @@ class CachedDRAMBuilder(DRAMBuilder):
     @property
     def sources(self):
         return "0,1"
+
+    @property
+    def is_coherent(self):
+        return True
 
     def create_dram(self, name):
         """

--- a/model/memory.py
+++ b/model/memory.py
@@ -1,0 +1,284 @@
+import sst
+from addressmap import *
+
+class MemoryBuilder(object):
+    """
+    A base class for a memory tile builder
+    """
+    def __init__(self):
+        """
+        Initialize the memory tile builder
+        """
+        super().__init__()
+        return
+    
+class Memory(object):
+    """
+    A base class for a memory tile
+    """
+    def __init__(self, name):
+        """
+        Initialize the memory tile
+        """
+        self.name = name
+        return
+
+    def network_if(self):
+        """
+        Returns the network interface subcomponent and port name
+        (interface, portname) pair
+        """
+        raise NotImplementedError("network_if() method not implemented")
+
+
+class L1SP(Memory):
+    """
+    A base class for a L1 SP
+    """
+    def __init__(self, name):
+        """
+        Initialize the L1 SP memory tile
+        """
+        super().__init__(name)
+        self.memctrl = None
+        self.backend = None
+        self.cmdhandler = None
+        self.nic = None
+        return
+
+    def network_interface(self):
+        return (self.nic, "port")
+
+class L1SPBuilder(MemoryBuilder):
+    """
+    A base class for a L1 SP
+    """
+    def __init__(self):
+        """
+        Initialize the L1 SP memory tile builder
+        """
+        super().__init__()
+        self.network_bw = "1GB/s"
+        self.size = 4*1024
+        self.clock = "1GHz"
+        self.access_time = "1ns"
+        return
+
+    def memctrl_name(self, name):
+        """
+        Return the name of the memory controller
+        """
+        return name + "_memctrl"
+
+    @property
+    def group(self):
+        """
+        Return the routing group number
+        """
+        return 1
+    
+    def build(self, system_builder, name):
+        """
+        Build the L1 SP memory tile
+        """
+        l1sp = L1SP(name)
+        addrmap = system_builder.addressmap()
+        addrrangebuilder = L1SPAddressBuilder(addrmap, self.size)
+        addr_start, addr_stop, _0, _1 = addrrangebuilder(
+            system_builder.pxn.id,
+            system_builder.pxn.pod.id,
+            system_builder.pxn.pod.compute.id,
+        )
+        # make the memory controller
+        l1sp.memctrl = sst.Component(self.memctrl_name(name),\
+                                     "memHierarchy.MemController")
+        l1sp.memctrl.addParams({
+            "clock" : self.clock,
+            "addr_range_start" : addr_start,
+            "addr_range_end" : addr_stop,
+        })
+
+        # make the backend
+        l1sp.backend = l1sp.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
+        l1sp.backend.addParams({
+            "access_time" : self.access_time,
+            "max_requests_per_cycle" : 1,            
+            "mem_size" : '{}B'.format(self.size),
+        })
+
+        # make the command handler
+        l1sp.cmdhandler = \
+            l1sp.memctrl.setSubComponent("customCmdHandler", "Drv.DrvCmdMemHandler")
+        
+        # make the nic
+        l1sp.nic = l1sp.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        l1sp.nic.addParams({
+            "group" : self.group,
+            "network_bw" : self.network_bw,
+        })
+        return l1sp
+
+class L2SP(Memory):
+    """
+    A base class for a L2SP
+    """
+    def __init__(self, name):
+        """
+        Initialize the L2 SP memory tile
+        """
+        super().__init__(name)
+        self.memctrl = None
+        self.backend = None
+        self.cmdhandler = None
+        self.nic = None
+        return
+
+    def network_interface(self):
+        return (self.nic, "port")
+
+class DRAM(Memory):
+    """
+    A base class for a DRAM
+    """
+    def __init__(self, name):
+        """
+        Initialize the DRAM memory tile
+        """
+        super().__init__(name)
+        self.memctrl = None
+        self.backend = None
+        self.cmdhandler = None
+        self.nic = None
+        return
+
+    def network_interface(self):
+        return (self.nic, "port")
+    
+class L2SPBuilder(MemoryBuilder):
+    """
+    A base class for a L2 SP memory tile builder
+    """
+    def __init__(self):
+        """
+        Initialize the L2 SP memory tile builder
+        """
+        self.id = 0
+        self.size = 64*1024
+        self.interleave_size = 0
+        self.interleave_step = 0
+        self.network_bw = "1GB/s"
+        return
+
+    def memctrl_name(self, name):
+        """
+        Return the name of the memory controller
+        """
+        return name + "_memctrl"
+
+    @property
+    def group(self):
+        return 2
+    
+    def build(self, system_builder, name):
+        l2sp = L2SP(name)
+        addrmap = system_builder.addressmap()
+        addrrangebuilder = L2SPAddressBuilder(addrmap, \
+                                              self.size, \
+                                              self.interleave_size, \
+                                              self.interleave_step)
+
+        addr_start, addr_stop, addr_interleave_size, addr_interleave_step \
+            = addrrangebuilder(system_builder.pxn.id, \
+                               system_builder.pxn.pod.id, \
+                               system_builder.pxn.pod.l2sp.id)
+
+        l2sp.memctrl = sst.Component(self.memctrl_name(name),\
+                                     "memHierarchy.MemController")
+        l2sp.memctrl.addParams({
+            "clock" : self.clock,
+            "addr_range_start" : addr_start,
+            "addr_range_end" : addr_stop,
+            "interleave_size" : '{}B'.format(addr_interleave_size),
+            "interleave_step" : '{}B'.format(addr_interleave_step),
+        })
+
+        l2sp.backend = l2sp.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
+        l2sp.backend.addParams({
+            "access_time" : self.access_time,
+            "max_requests_per_cycle" : 1,
+            "mem_size" : '{}B'.format(self.size),
+        })
+
+        l2sp.cmdhandler = \
+            l2sp.memctrl.setSubComponent("customCmdHandler", "Drv.DrvCmdMemHandler")
+
+        l2sp.nic = l2sp.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        l2sp.nic.addParams({
+            "group" : self.group,
+            "network_bw" : self.network_bw,
+        })
+        return l2sp
+
+class DRAMBuilder(MemoryBuilder):
+    """
+    A base class for a DRAM memory tile builder
+    """
+    def __init__(self):
+        """
+        Initialize the DRAM memory tile builder
+        """
+        super().__init__()
+        self.id = 0
+        self.size = 1024*1024*1024
+        self.interleave_size = 0
+        self.interleave_step = 0
+        self.network_bw = "1GB/s"
+        return
+
+    def memctrl_name(self, name):
+        """
+        Return the name of the memory controller
+        """
+        return name + "_memctrl"
+
+    @property
+    def group(self):
+        return 2
+    
+    def build(self, system_builder, name):
+        dram = DRAM(name)
+        addrmap = system_builder.addressmap()
+        addrrangebuilder = DRAMAddressBuilder(addrmap, \
+                                              self.size, \
+                                              self.interleave_size, \
+                                              self.interleave_step)
+        addr_start, addr_stop, addr_interleave_size, addr_interleave_step \
+            = addrrangebuilder(system_builder.pxn.id, \
+                               system_builder.pxn.dram.id)
+        dram.memctrl = sst.Component(self.memctrl_name(name),\
+                                     "memHierarchy.MemController")
+        dram.memctrl.addParams({
+            "clock" : self.clock,
+            "addr_range_start" : addr_start,
+            "addr_range_end" : addr_stop,
+            "interleave_size" : '{}B'.format(addr_interleave_size),
+            "interleave_step" : '{}B'.format(addr_interleave_step),
+        })
+
+        dram.backend = dram.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
+        dram.backend.addParams({
+            "access_time" : self.access_time,
+            "mem_size" : '{}B'.format(self.size),
+            "max_requests_per_cycle" : 1,            
+        })
+
+        dram.cmdhandler = \
+            dram.memctrl.setSubComponent("customCmdHandler", "Drv.DrvCmdMemHandler")
+
+        dram.nic = dram.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        dram.nic.addParams({
+            "group" : self.group,
+            "network_bw" : self.network_bw,
+        })
+        return dram
+

--- a/model/memory.py
+++ b/model/memory.py
@@ -1,6 +1,5 @@
 import sst
 from addressmap import *
-from constants import *
 
 class MemoryBuilder(object):
     """

--- a/model/memory.py
+++ b/model/memory.py
@@ -12,7 +12,15 @@ class MemoryBuilder(object):
         """
         super().__init__()
         return
-    
+
+
+    @property
+    def group(self):
+        """
+        Return the routing group number
+        """
+        return 2
+
 class Memory(object):
     """
     A base class for a memory tile
@@ -70,13 +78,6 @@ class L1SPBuilder(MemoryBuilder):
         Return the name of the memory controller
         """
         return name + "_memctrl"
-
-    @property
-    def group(self):
-        """
-        Return the routing group number
-        """
-        return 1
     
     def build(self, system_builder, name):
         """
@@ -158,10 +159,6 @@ class L2SPBuilder(MemoryBuilder):
         Return the name of the memory controller
         """
         return name + "_memctrl"
-
-    @property
-    def group(self):
-        return 2
     
     def build(self, system_builder, name):
         l2sp = L2SP(name)
@@ -225,10 +222,6 @@ class DRAMBuilder(MemoryBuilder):
         Return the name of the memory controller
         """
         return name + "_memctrl"
-
-    @property
-    def group(self):
-        return 2
 
     def address_range(self, system_builder):
         """

--- a/model/memory.py
+++ b/model/memory.py
@@ -104,7 +104,7 @@ class L1SPBuilder(MemoryBuilder):
         l1sp.backend.addParams({
             "access_time" : self.access_time,
             "max_requests_per_cycle" : 1,
-            "mem_size" : '{}B'.format(self.size),
+            "mem_size" : f'{self.size}B',
         })
 
         # make the command handler
@@ -178,15 +178,15 @@ class L2SPBuilder(MemoryBuilder):
             "clock" : self.clock,
             "addr_range_start" : addr_start,
             "addr_range_end" : addr_stop,
-            "interleave_size" : '{}B'.format(addr_interleave_size),
-            "interleave_step" : '{}B'.format(addr_interleave_step),
+            "interleave_size" : f'{addr_interleave_size}B',
+            "interleave_step" : f'{addr_interleave_step}B'
         })
 
         l2sp.backend = l2sp.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
         l2sp.backend.addParams({
             "access_time" : self.access_time,
             "max_requests_per_cycle" : 1,
-            "mem_size" : '{}B'.format(self.size),
+            "mem_size" : f'{self.size}B',
         })
 
         l2sp.cmdhandler = \
@@ -259,15 +259,15 @@ class DRAMBuilder(MemoryBuilder):
             "clock" : self.clock,
             "addr_range_start" : addr_start,
             "addr_range_end" : addr_stop,
-            "interleave_size" : '{}B'.format(addr_interleave_size),
-            "interleave_step" : '{}B'.format(addr_interleave_step),
+            "interleave_size" : f'{addr_interleave_size}B',
+            "interleave_step" : f'{addr_interleave_step}B',
             "max_requests_per_cycle" : 1,
         })
 
         dram.backend = dram.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
         dram.backend.addParams({
             "access_time" : self.access_time,
-            "mem_size" : '{}B'.format(self.size),
+            "mem_size" : f'{self.size}B',
             "max_requests_per_cycle" : 1,            
         })
 
@@ -412,7 +412,7 @@ class CachedDRAMBuilder(DRAMBuilder):
         dram.cache.addParams({
             "cache_frequency" : self.clock,
             # cache size, associativity, replacement policy, etc.
-            "cache_size" : '{}B'.format(self.cache_size),
+            "cache_size" : f'{self.cache_size}B',
             "associativity" : self.cache_assoc,
             "cache_line_size" : self.cache_line_size,
             "mshr_num_entries" : self.mshr_num_entries,
@@ -421,8 +421,8 @@ class CachedDRAMBuilder(DRAMBuilder):
             # routing information
             "addr_range_start" : addr_start,
             "addr_range_end" : addr_stop,
-            "interleave_size" : '{}B'.format(addr_interleave_size),
-            "interleave_step" : '{}B'.format(addr_interleave_step),
+            "interleave_size" : f'{addr_interleave_size}B',
+            "interleave_step" : f'{addr_interleave_step}B',
             # required for this to work; don't change
             "L1" : "true",
             "coherence_protocol" : "mesi",
@@ -434,7 +434,7 @@ class CachedDRAMBuilder(DRAMBuilder):
                                                         "memHierarchy.MemLink")
         dram.cache_memlink = dram.cache.setSubComponent("memlink", \
                                                         "memHierarchy.MemLink")
-        link = sst.Link("link_{}_to_{}".format(self.cache_name(name), self.memctrl_name(name)))
+        link = sst.Link(f"link_{self.cache_name(name)}_to_{self.memctrl_name(name)}")
         link.connect((dram.cache_memlink, "port", "1ns"), \
                      (dram.mem_cpulink, "port", "1ns"))
 

--- a/model/memory.py
+++ b/model/memory.py
@@ -1,5 +1,6 @@
 import sst
 from addressmap import *
+from constants import *
 
 class MemoryBuilder(object):
     """
@@ -23,7 +24,7 @@ class Memory(object):
         self.name = name
         return
 
-    def network_if(self):
+    def network_interface(self):
         """
         Returns the network interface subcomponent and port name
         (interface, portname) pair
@@ -58,7 +59,7 @@ class L1SPBuilder(MemoryBuilder):
         Initialize the L1 SP memory tile builder
         """
         super().__init__()
-        self.network_bw = "1GB/s"
+        self.network_bw = "24GB/s"
         self.size = 4*1024
         self.clock = "1GHz"
         self.access_time = "1ns"
@@ -102,7 +103,7 @@ class L1SPBuilder(MemoryBuilder):
         l1sp.backend = l1sp.memctrl.setSubComponent("backend", "Drv.DrvSimpleMemBackend")
         l1sp.backend.addParams({
             "access_time" : self.access_time,
-            "max_requests_per_cycle" : 1,            
+            "max_requests_per_cycle" : 1,
             "mem_size" : '{}B'.format(self.size),
         })
 
@@ -136,24 +137,6 @@ class L2SP(Memory):
     def network_interface(self):
         return (self.nic, "port")
 
-class DRAM(Memory):
-    """
-    A base class for a DRAM
-    """
-    def __init__(self, name):
-        """
-        Initialize the DRAM memory tile
-        """
-        super().__init__(name)
-        self.memctrl = None
-        self.backend = None
-        self.cmdhandler = None
-        self.nic = None
-        return
-
-    def network_interface(self):
-        return (self.nic, "port")
-    
 class L2SPBuilder(MemoryBuilder):
     """
     A base class for a L2 SP memory tile builder
@@ -167,6 +150,7 @@ class L2SPBuilder(MemoryBuilder):
         self.interleave_size = 0
         self.interleave_step = 0
         self.network_bw = "1GB/s"
+        self.clock = "1GHz"
         return
 
     def memctrl_name(self, name):
@@ -233,6 +217,7 @@ class DRAMBuilder(MemoryBuilder):
         self.interleave_size = 0
         self.interleave_step = 0
         self.network_bw = "1GB/s"
+        self.clock = "1GHz"
         return
 
     def memctrl_name(self, name):
@@ -244,17 +229,27 @@ class DRAMBuilder(MemoryBuilder):
     @property
     def group(self):
         return 2
-    
-    def build(self, system_builder, name):
-        dram = DRAM(name)
+
+    def address_range(self, system_builder):
+        """
+        Return (start, stop, interleave_size, interleave_step)
+        """
         addrmap = system_builder.addressmap()
         addrrangebuilder = DRAMAddressBuilder(addrmap, \
                                               self.size, \
                                               self.interleave_size, \
                                               self.interleave_step)
+        return addrrangebuilder(system_builder.pxn.id, \
+                                system_builder.pxn.dram.id)
+
+    def build_dram(self, system_builder, name):
+        """
+        Build the DRAM memory tile
+        """
+        dram = self.create_dram(name)
         addr_start, addr_stop, addr_interleave_size, addr_interleave_step \
-            = addrrangebuilder(system_builder.pxn.id, \
-                               system_builder.pxn.dram.id)
+            = self.address_range(system_builder)
+
         dram.memctrl = sst.Component(self.memctrl_name(name),\
                                      "memHierarchy.MemController")
         dram.memctrl.addParams({
@@ -275,6 +270,56 @@ class DRAMBuilder(MemoryBuilder):
         dram.cmdhandler = \
             dram.memctrl.setSubComponent("customCmdHandler", "Drv.DrvCmdMemHandler")
 
+        return dram
+
+    def create_dram(self, name):
+        """
+        Create the DRAM memory tile
+        """
+        raise NotImplementedError("create_dram() is not implemented")
+
+
+    def build(self, system_builder, name):
+        raise NotImplementedError("build() is not implemented")
+
+class NoCacheDRAM(Memory):
+    """
+    A base class for a DRAM
+    """
+    def __init__(self, name):
+        """
+        Initialize the DRAM memory tile
+        """
+        super().__init__(name)
+        self.memctrl = None
+        self.backend = None
+        self.cmdhandler = None
+        self.nic = None
+        return
+
+    def network_interface(self):
+        return (self.nic, "port")
+
+class NoCacheDRAMBuilder(DRAMBuilder):
+    """
+    A base class for a DRAM memory tile builder
+    """
+    def __init__(self):
+        """
+        Initialize the DRAM memory tile builder
+        """
+        super().__init__()
+        return
+
+    def create_dram(self, name):
+        """
+        Create the DRAM memory tile
+        """
+        return NoCacheDRAM(name)
+
+    def build(self, system_builder, name):
+        dram = self.build_dram(system_builder, name)
+        # create the network interface
         dram.nic = dram.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
         dram.nic.addParams({
             "group" : self.group,
@@ -282,3 +327,107 @@ class DRAMBuilder(MemoryBuilder):
         })
         return dram
 
+class CachedDRAM(Memory):
+    """
+    A base class for a DRAM bank with a cache in front of it
+    """
+    def __init__(self, name):
+        """
+        Initialize the cached DRAM memory tile
+        """
+        super().__init__(name)
+        self.memctrl = None
+        self.backend = None
+        self.cmdhandler = None
+        self.cache = None
+        self.mem_cpulink = None # nic going to the memory
+        self.cache_memlink = None # cache nic going to the memory
+        self.cache_cpunic = None # cache nic going to the cpu
+        return
+
+    def network_interface(self):
+        return (self.cache_cpunic, "port")
+
+class CachedDRAMBuilder(DRAMBuilder):
+    """
+    Builds a DRAM bank with a cache in front of it
+    """
+    def __init__(self):
+        """
+        Initialize the cached DRAM memory tile builder
+        """
+        super().__init__()
+        self.id = 0
+        self.size = 1024*1024*1024
+        self.interleave_size = 0
+        self.interleave_step = 0
+        self.network_bw = "1GB/s"
+        self.cache_size = 64*1024
+        self.cache_assoc = 8
+        self.cache_line_size = 64
+        self.clock = "1GHz"
+        self.mshr_num_entries = 16
+        return
+
+    def cache_name(self, name):
+        """
+        Return the name of the cache
+        """
+        return name + "_cache"
+
+    @property
+    def sources(self):
+        return "0,1"
+
+    def create_dram(self, name):
+        """
+        Create the DRAM memory tile
+        """
+        return CachedDRAM(name)
+
+    def build(self, system_builder, name):
+        dram = self.build_dram(system_builder, name)
+
+        addr_start, addr_stop, addr_interleave_size, addr_interleave_step \
+            = self.address_range(system_builder)
+
+        # create the cache
+        dram.cache = sst.Component(self.cache_name(name), "memHierarchy.Cache")
+        dram.cache.addParams({
+            "cache_frequency" : self.clock,
+            # cache size, associativity, replacement policy, etc.
+            "cache_size" : '{}B'.format(self.cache_size),
+            "associativity" : self.cache_assoc,
+            "cache_line_size" : self.cache_line_size,
+            "mshr_num_entries" : self.mshr_num_entries,
+            "replacement_policy" : "lru",
+            "access_latency_cycles" : 1,
+            # routing information
+            "addr_range_start" : addr_start,
+            "addr_range_end" : addr_stop,
+            "interleave_size" : '{}B'.format(addr_interleave_size),
+            "interleave_step" : '{}B'.format(addr_interleave_step),
+            # required for this to work; don't change
+            "L1" : "true",
+            "coherence_protocol" : "mesi",
+            "cache_type" : "inclusive"
+        })
+
+        # connect the cache to the memory
+        dram.mem_cpulink = dram.memctrl.setSubComponent("cpulink", \
+                                                        "memHierarchy.MemLink")
+        dram.cache_memlink = dram.cache.setSubComponent("memlink", \
+                                                        "memHierarchy.MemLink")
+        link = sst.Link("link_{}_to_{}".format(self.cache_name(name), self.memctrl_name(name)))
+        link.connect((dram.cache_memlink, "port", "1ns"), \
+                     (dram.mem_cpulink, "port", "1ns"))
+
+        # create the NIC for the memory
+        dram.cache_cpunic = dram.cache.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        dram.cache_cpunic.addParams({
+            "group" : self.group,
+            "sources" : self.sources,
+            "network_bw" : self.network_bw,
+        })
+
+        return dram

--- a/model/mesh.py
+++ b/model/mesh.py
@@ -1,128 +1,233 @@
 import itertools
-from sst.merlin import *
 import sst
 import enum
 
-X = 4
-Y = 3
+X = 1
+Y = 2
 
-# x direction
-EAST =  (0, 0)
-WEST =  (0, 1)
-
-# y direction
-NORTH = (1, 0)
-SOUTH = (1, 1)
-
-class Identifiable(object):
-    def id(self, x, y):
-        # dimension order x than y
-        return y*X + x
 
 CPU_VERBOSE_LEVEL = 1
-NETWORK_DEBUG_LEVEL = 0
-
-def portof(direction):
-    dim, neg = direction
-    return 2*dim + neg
-
-DIRECTIONS = [NORTH, SOUTH, EAST, WEST]
-
+NETWORK_DEBUG_LEVEL = 1
 UPDATES_PER_CORE = 100
 
-class Memory(Identifiable):
-    size = 1024
+class Mesh(object):
     def __init__(self):
-        pass
+        self.tiles = {}
+
+class MeshBuilder(object):
+    # x direction
+    EAST =  (0, 0)
+    WEST =  (0, 1)
+    # y direction
+    NORTH = (1, 0)
+    SOUTH = (1, 1)
+    # local ports
+    LOCAL0 = (2, 0)
+    LOCAL1 = (2, 1)
+
+    @classmethod
+    def portof(cls, direction):
+        dim, neg = direction
+        return 2*dim + neg
+
+    @classmethod
+    def west_port(cls):
+        return cls.portof(cls.WEST)
+
+    @classmethod
+    def east_port(cls):
+        return cls.portof(cls.EAST)
+
+    @classmethod
+    def north_port(cls):
+        return cls.portof(cls.NORTH)
+
+    @classmethod
+    def south_port(cls):
+        return cls.portof(cls.SOUTH)
+
+    def __init__(self, xdim, ydim, meshid):
+        self.xdim = xdim
+        self.ydim = ydim
+        self.meshid = meshid
+        self.tile_builder = {
+            (x,y) : ComputeTileBuilder for (x,y) in itertools.product(range(xdim), range(ydim))
+        }
+
+    def build(self):
+        mesh = Mesh()
+        # build all tiles
+        for (x,y) in itertools.product(range(self.xdim), range(self.ydim)):
+            bldr = self.tile_builder[(x,y)](self.xdim, self.ydim, self.meshid)
+            mesh.tiles[(x,y)] = bldr.build(x, y)
+
+        # connect all tiles
+        for (x,y) in itertools.product(range(self.xdim), range(self.ydim)):
+            # connect to north neighbor
+            if y < self.ydim-1:
+                link = sst.Link(f"link_{x}x{y}_to_{x}x{y+1}_mesh{self.meshid}")
+                link.connect(mesh.tiles[(x,y)].north, mesh.tiles[(x,y+1)].south)
+            # connect to east neighbor
+            if x < self.xdim-1:
+                link = sst.Link(f"link_{x}x{y}_to_{x+1}x{y}_mesh{self.meshid}")
+                link.connect(mesh.tiles[(x,y)].east, mesh.tiles[(x+1,y)].west)
+
+        return mesh
+
+class Identifiable(object):
+    def __init__(self, xdim, ydim, meshid):
+        self.xdim = xdim
+        self.ydim = ydim
+        self.meshid = meshid
+
+    def id(self, x, y):
+        # dimension order x than y
+        return y*self.xdim + x
+
+    def absid(self, x, y):
+        return self.id(x, y) + self.meshid * self.xdim * self.ydim
+
+class Memory(object):
+    def __init__(self):
+        self.controller = None
+        self.backend = None
+        self.nic = None    
+
+    @property
+    def network_interface(self):
+        return (self.nic, "port", "1ns")
+    
+class MemoryBuilder(Identifiable):
+    size = 1024
+    def __init__(self, xdim, ydim, meshid):
+        super().__init__(xdim, ydim, meshid)
 
     def build(self, x, y):
-        memory = sst.Component(f"memory_{x}_{y}", "memHierarchy.MemController")
-        start = self.id(x, y) * Memory.size
-        end = (self.id(x, y) + 1) * Memory.size - 1
+        memory = Memory()
+        memory.controller = sst.Component(f"memory_{x}_{y}_mesh{self.meshid}", "memHierarchy.MemController")
+        start = self.absid(x, y) * MemoryBuilder.size
+        end = (self.absid(x, y) + 1) * MemoryBuilder.size - 1
         print(f"Memory {x} {y} {start:x}-{end:x}")
-        memory.addParams({
+        memory.controller.addParams({
             "debug_level" : 10,
             "verbose" : 0,
             "clock" : "1GHz",
             "addr_range_start" : start,
             "addr_range_end" : end,
-            "interleave_size" : f"{Memory.size}B",
-            "interleave_step" : f"{X*Y*Memory.size}B",
+            "interleave_size" : f"{MemoryBuilder.size}B",
+            "interleave_step" : f"{X*Y*MemoryBuilder.size}B",
         })
-        backend = memory.setSubComponent("backend", "memHierarchy.simpleMem")
-        backend.addParams({
+        memory.backend = memory.controller.setSubComponent("backend", "memHierarchy.simpleMem")
+        memory.backend.addParams({
             "access_time" : "1ns",
-            "mem_size" : f"{Memory.size}B",
+            "mem_size" : f"{MemoryBuilder.size}B",
         })
-        nic = memory.setSubComponent("cpulink", "memHierarchy.MemNIC")
-        nic.addParams({
+        memory.nic = memory.controller.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        memory.nic.addParams({
             "group" : "1",
             "network_bw" : "1024GB/s",
             "sources" : "0",
             "debug_level" : NETWORK_DEBUG_LEVEL,
             "debug" : 1,
         })
-        return (nic, "port", "1ns")
+        return memory
 
-class Core(Identifiable):
+class Core(object):
     def __init__(self):
-        pass
+        self.core = None
+        self.generator = None
+        self.interface = None
+        self.nic = None
+
+    @property
+    def network_interface(self):
+        return (self.nic, "port", "1ns")
+
+class CoreBuilder(Identifiable):
+    def __init__(self, xdim, ydim, meshid):
+        super().__init__(xdim, ydim, meshid)
 
     def build(self, x, y):
-        core = sst.Component(f"core_{x}_{y}", "miranda.BaseCPU")
-        core.addParams({
+        core = Core()
+        core.core = sst.Component(f"core_{x}_{y}_mesh{self.meshid}", "miranda.BaseCPU")
+        core.core.addParams({
             "verbose" : CPU_VERBOSE_LEVEL,
             "maxloadmemreqpending" : 1,
             "maxstorememreqpending" : 1,
             "maxcustommemreqpending" : 1,
         })
-        generator = core.setSubComponent("generator", "miranda.GUPSGenerator")
-        generator.addParams({
+        core.generator = core.core.setSubComponent("generator", "miranda.GUPSGenerator")
+        core.generator.addParams({
             "verbose" : 4,            
-            "max_address" : Memory.size * X * Y - 8,
+            "max_address" : MemoryBuilder.size * X * Y - 8,
             "count" : UPDATES_PER_CORE,
             "clock" : "1GHz",
             "seed_a" : self.id(x, y),
             "seed_b" : 7*self.id(x, y)+1,
         })
-        interface = core.setSubComponent("memory", "memHierarchy.standardInterface")
-        nic = interface.setSubComponent("memlink", "memHierarchy.MemNIC")
-        nic.addParams({
+        core.interface = core.core.setSubComponent("memory", "memHierarchy.standardInterface")
+        core.nic = core.interface.setSubComponent("memlink", "memHierarchy.MemNIC")
+        core.nic.addParams({
             "group" : "0",
             "network_bw" : "1024GB/s",
             "destinations" : "1",
             "debug_level" : NETWORK_DEBUG_LEVEL,
             "debug" : 1,
         })
-        return (nic, "port", "1ns")
-    
-class Tile(Identifiable):
+        return core
+
+class MeshTile(object):
     def __init__(self):
-        self.core = Core()
-        self.memory = Memory()
+        self.router = None
+        self.memory = None
+        self.core = None
 
-    def num_ports(self, x, y):
-        local = 2
-        network = 4
-        return local + network    
-
-    def ports(self, x, y, router):
-        ports = {
-            WEST  : (router, f"port{portof(WEST)}", "1ns"),
-            EAST  : (router, f"port{portof(EAST)}", "1ns"),
-            NORTH : (router, f"port{portof(NORTH)}", "1ns"),
-            SOUTH : (router, f"port{portof(SOUTH)}", "1ns"),
+    @property
+    def network_interfaces(self):
+        return {
+            MeshBuilder.WEST  : (self.router, f"port{MeshBuilder.west_port()}", "1ns"),
+            MeshBuilder.EAST  : (self.router, f"port{MeshBuilder.east_port()}", "1ns"),
+            MeshBuilder.NORTH : (self.router, f"port{MeshBuilder.north_port()}", "1ns"),
+            MeshBuilder.SOUTH : (self.router, f"port{MeshBuilder.south_port()}", "1ns"),
+            MeshBuilder.LOCAL0 : (self.router, f"port{MeshBuilder.portof(MeshBuilder.LOCAL0)}", "1ns"),
+            MeshBuilder.LOCAL1 : (self.router, f"port{MeshBuilder.portof(MeshBuilder.LOCAL1)}", "1ns"),
         }
-        return ports
 
-    def core_port(self):
-        return "port4"
+    @property
+    def north(self):
+        return self.network_interfaces[MeshBuilder.NORTH]
 
-    def memory_port(self):
-        return "port5"
+    @property
+    def south(self):
+        return self.network_interfaces[MeshBuilder.SOUTH]
+
+    @property
+    def east(self):
+        return self.network_interfaces[MeshBuilder.EAST]
+
+    @property
+    def west(self):
+        return self.network_interfaces[MeshBuilder.WEST]
+
+    @property
+    def local0(self):
+        return self.network_interfaces[MeshBuilder.LOCAL0]
+
+    @property
+    def local1(self):
+        return self.network_interfaces[MeshBuilder.LOCAL1]
     
-    def build(self, x, y):
-        router = sst.Component(f"router_{x:02}_{y:02}", "merlin.hr_router")
+class MeshTileBuilder(Identifiable):
+    def __init__(self, xdim, ydim, meshid):
+        self.local_ports = 2
+        super().__init__(xdim, ydim, meshid)
+
+    @property
+    def num_ports(self):
+        return self.local_ports + 4
+
+    def build_router(self, x, y):
+        router = sst.Component(f"router_{x}_{y}_mesh{self.meshid}", "merlin.hr_router")
         router.addParams({
             "id" : self.id(x, y),
             "num_vns" : 2,
@@ -133,7 +238,7 @@ class Tile(Identifiable):
             "input_buf_size" : "1KB",
             "output_buf_size" : "1KB",
             "flit_size" : "8B",
-            "num_ports" : self.num_ports(x,y),
+            "num_ports" : self.num_ports,
         })
         topo = router.setSubComponent("topology", "merlin.mesh")
         topo.addParams({
@@ -141,27 +246,99 @@ class Tile(Identifiable):
             "width" : "1",
             "local_ports" : "2",
         })
-        core_if, core_port, core_latency = self.core.build(x, y)
-        link = sst.Link(f"link_core_router_{x}_{y}")
-        link.connect((core_if, core_port, core_latency), (router, self.core_port(), "1ns"))
+        return router
+            
+    def build(self, x, y):
+        mesh_tile = self.make_mesh_tile()
+        mesh_tile.router = self.build_router(x, y)
+        self.build_local_endpoints(x, y, mesh_tile)
+        return mesh_tile
 
-        mem_if, mem_port, mem_latency = self.memory.build(x, y)
-        link = sst.Link(f"link_router_memory_{x}_{y}")
-        link.connect((router, self.memory_port(), "1ns"), (mem_if, mem_port, mem_latency))
-        return self.ports(x, y, router)
-        
-tile = Tile()
-nodes = {}
-for (x,y) in itertools.product(range(X), range(Y)):
-    nodes[(x,y)] = tile.build(x, y)
-
-for (x,y) in itertools.product(range(X), range(Y)):
-    # connect to north neighbor
-    if y < Y-1:
-        link = sst.Link(f"link_{x}x{y}_to_{x}x{y+1}")
-        link.connect(nodes[(x,y)][NORTH], nodes[(x,y+1)][SOUTH])
-    # connect to east neighbor
-    if x < X-1:
-        link = sst.Link(f"link_{x}x{y}_to_{x+1}x{y}")
-        link.connect(nodes[(x,y)][EAST], nodes[(x+1,y)][WEST])
+    def make_mesh_tile(self):
+        raise NotImplementedError("MeshTileBuilder.make_mesh_tile")
     
+    def build_local_endpoints(self, x, y, mesh_tile):
+        raise NotImplementedError("MeshTile.build_local_endpoints")
+
+class ComputeTile(MeshTile):
+    def __init__(self):
+        super().__init__()
+        self.core = None
+        self.memory = None
+
+class ComputeTileBuilder(MeshTileBuilder):
+    def __init__(self, xdim, ydim, meshid):
+        self.core = CoreBuilder(xdim, ydim, meshid)
+        self.memory = MemoryBuilder(xdim, ydim, meshid)
+        super().__init__(xdim, ydim, meshid)
+
+    def make_mesh_tile(self):
+        return ComputeTile()
+
+    def build_local_endpoints(self, x, y, tile):
+        print(f"ComputeTile {x} {y}")
+        tile.core = self.core.build(x, y)
+        link = sst.Link(f"link_core_router_{x}_{y}_mesh{self.meshid}")
+        link.connect(tile.core.network_interface, tile.local0)
+
+        tile.memory = self.memory.build(x, y)
+        link = sst.Link(f"link_router_memory_{x}_{y}_mesh{self.meshid}")
+        link.connect(tile.memory.network_interface, tile.local1)
+
+
+class EmptyTile(MeshTile):
+    def __init__(self):
+        super().__init__()
+
+class EmptyTileBuilder(MeshTileBuilder):
+    def __init__(self, xdim, ydim, meshid):
+        super().__init__(xdim, ydim, meshid)
+
+    def make_mesh_tile(self):
+        return EmptyTile()
+
+    def build_local_endpoints(self, x, y, tile):
+        pass
+
+
+if 0:
+    # unclear if this would work
+    bidx = (0,1)
+
+    mesh_builder0 = MeshBuilder(X, Y, 0)
+    mesh_builder0.tile_builder[bidx] = EmptyTileBuilder
+    mesh0 = mesh_builder0.build()
+
+    mesh_builder1 = MeshBuilder(X, Y, 1)
+    mesh_builder1.tile_builder[bidx] = EmptyTileBuilder
+    mesh1 = mesh_builder1.build()
+
+    # router = sst.Component("router", "merlin.hr_router")
+    # router.addParams({
+    #     "id" : 0,
+    #     "num_vns" : 1,
+    #     "xbar_bw" : "1024GB/s",
+    #     "link_bw" : "1024GB/s",
+    #     "input_latency" : "1ns",
+    #     "output_latency" : "1ns",
+    #     "input_buf_size" : "1KB",
+    #     "output_buf_size" : "1KB",
+    #     "flit_size" : "8B",
+    #     "num_ports" : 2,
+    # })
+    # topo = router.setSubComponent("topology", "merlin.singlerouter")
+
+    bridge = sst.Component("bridge", "merlin.Bridge")
+    bridge.addParams({
+        "translator" : "memHierarchy.MemNetBridge",
+        "network_bw" : "1024GB/s",
+    })
+
+    link = sst.Link("link_router_mesh0")
+    link.connect(mesh0.tiles[bidx].local0, (bridge, "network0", "1ns"))
+    
+    link = sst.Link("link_router_mesh1")
+    link.connect(mesh1.tiles[bidx].local0, (bridge, "network1", "1ns"))
+else:
+    mesh_builder = MeshBuilder(X, Y, 0)
+    mesh = mesh_builder.build()

--- a/model/mesh.py
+++ b/model/mesh.py
@@ -3,17 +3,21 @@ from sst.merlin import *
 import sst
 import enum
 
-X = 2
-Y = 2
+X = 4
+Y = 3
 
-NORTH = (0, 0)
-SOUTH = (0, 1)
-EAST =  (1, 0)
-WEST =  (1, 1)
+# x direction
+EAST =  (0, 0)
+WEST =  (0, 1)
+
+# y direction
+NORTH = (1, 0)
+SOUTH = (1, 1)
 
 class Identifiable(object):
     def id(self, x, y):
-        return x * Y + y
+        # dimension order x than y
+        return y*X + x
 
 CPU_VERBOSE_LEVEL = 1
 NETWORK_DEBUG_LEVEL = 0
@@ -23,6 +27,8 @@ def portof(direction):
     return 2*dim + neg
 
 DIRECTIONS = [NORTH, SOUTH, EAST, WEST]
+
+UPDATES_PER_CORE = 100
 
 class Memory(Identifiable):
     size = 1024
@@ -74,7 +80,7 @@ class Core(Identifiable):
         generator.addParams({
             "verbose" : 4,            
             "max_address" : Memory.size * X * Y - 8,
-            "count" : 100,
+            "count" : UPDATES_PER_CORE,
             "clock" : "1GHz",
             "seed_a" : self.id(x, y),
             "seed_b" : 7*self.id(x, y)+1,
@@ -149,13 +155,13 @@ nodes = {}
 for (x,y) in itertools.product(range(X), range(Y)):
     nodes[(x,y)] = tile.build(x, y)
 
-link_00_10 = sst.Link("link_00_10")
-link_00_01 = sst.Link("link_00_01")
-link_01_11 = sst.Link("link_01_11")
-link_10_11 = sst.Link("link_10_11")
-
-link_00_01.connect(nodes[(0,0)][NORTH], nodes[(0,1)][SOUTH])
-link_00_10.connect(nodes[(0,0)][EAST],  nodes[(1,0)][WEST])
-link_01_11.connect(nodes[(0,1)][EAST],  nodes[(1,1)][WEST])
-link_10_11.connect(nodes[(1,0)][NORTH], nodes[(1,1)][SOUTH])
-
+for (x,y) in itertools.product(range(X), range(Y)):
+    # connect to north neighbor
+    if y < Y-1:
+        link = sst.Link(f"link_{x}x{y}_to_{x}x{y+1}")
+        link.connect(nodes[(x,y)][NORTH], nodes[(x,y+1)][SOUTH])
+    # connect to east neighbor
+    if x < X-1:
+        link = sst.Link(f"link_{x}x{y}_to_{x+1}x{y}")
+        link.connect(nodes[(x,y)][EAST], nodes[(x+1,y)][WEST])
+    

--- a/model/mesh.py
+++ b/model/mesh.py
@@ -1,0 +1,161 @@
+import itertools
+from sst.merlin import *
+import sst
+import enum
+
+X = 2
+Y = 2
+
+NORTH = (0, 0)
+SOUTH = (0, 1)
+EAST =  (1, 0)
+WEST =  (1, 1)
+
+class Identifiable(object):
+    def id(self, x, y):
+        return x * Y + y
+
+CPU_VERBOSE_LEVEL = 1
+NETWORK_DEBUG_LEVEL = 0
+
+def portof(direction):
+    dim, neg = direction
+    return 2*dim + neg
+
+DIRECTIONS = [NORTH, SOUTH, EAST, WEST]
+
+class Memory(Identifiable):
+    size = 1024
+    def __init__(self):
+        pass
+
+    def build(self, x, y):
+        memory = sst.Component(f"memory_{x}_{y}", "memHierarchy.MemController")
+        start = self.id(x, y) * Memory.size
+        end = (self.id(x, y) + 1) * Memory.size - 1
+        print(f"Memory {x} {y} {start:x}-{end:x}")
+        memory.addParams({
+            "debug_level" : 10,
+            "verbose" : 0,
+            "clock" : "1GHz",
+            "addr_range_start" : start,
+            "addr_range_end" : end,
+            "interleave_size" : f"{Memory.size}B",
+            "interleave_step" : f"{X*Y*Memory.size}B",
+        })
+        backend = memory.setSubComponent("backend", "memHierarchy.simpleMem")
+        backend.addParams({
+            "access_time" : "1ns",
+            "mem_size" : f"{Memory.size}B",
+        })
+        nic = memory.setSubComponent("cpulink", "memHierarchy.MemNIC")
+        nic.addParams({
+            "group" : "1",
+            "network_bw" : "1024GB/s",
+            "sources" : "0",
+            "debug_level" : NETWORK_DEBUG_LEVEL,
+            "debug" : 1,
+        })
+        return (nic, "port", "1ns")
+
+class Core(Identifiable):
+    def __init__(self):
+        pass
+
+    def build(self, x, y):
+        core = sst.Component(f"core_{x}_{y}", "miranda.BaseCPU")
+        core.addParams({
+            "verbose" : CPU_VERBOSE_LEVEL,
+            "maxloadmemreqpending" : 1,
+            "maxstorememreqpending" : 1,
+            "maxcustommemreqpending" : 1,
+        })
+        generator = core.setSubComponent("generator", "miranda.GUPSGenerator")
+        generator.addParams({
+            "verbose" : 4,            
+            "max_address" : Memory.size * X * Y - 8,
+            "count" : 100,
+            "clock" : "1GHz",
+            "seed_a" : self.id(x, y),
+            "seed_b" : 7*self.id(x, y)+1,
+        })
+        interface = core.setSubComponent("memory", "memHierarchy.standardInterface")
+        nic = interface.setSubComponent("memlink", "memHierarchy.MemNIC")
+        nic.addParams({
+            "group" : "0",
+            "network_bw" : "1024GB/s",
+            "destinations" : "1",
+            "debug_level" : NETWORK_DEBUG_LEVEL,
+            "debug" : 1,
+        })
+        return (nic, "port", "1ns")
+    
+class Tile(Identifiable):
+    def __init__(self):
+        self.core = Core()
+        self.memory = Memory()
+
+    def num_ports(self, x, y):
+        local = 2
+        network = 4
+        return local + network    
+
+    def ports(self, x, y, router):
+        ports = {
+            WEST  : (router, f"port{portof(WEST)}", "1ns"),
+            EAST  : (router, f"port{portof(EAST)}", "1ns"),
+            NORTH : (router, f"port{portof(NORTH)}", "1ns"),
+            SOUTH : (router, f"port{portof(SOUTH)}", "1ns"),
+        }
+        return ports
+
+    def core_port(self):
+        return "port4"
+
+    def memory_port(self):
+        return "port5"
+    
+    def build(self, x, y):
+        router = sst.Component(f"router_{x:02}_{y:02}", "merlin.hr_router")
+        router.addParams({
+            "id" : self.id(x, y),
+            "num_vns" : 2,
+            "xbar_bw" : "1024GB/s",
+            "link_bw" : "1024GB/s",
+            "input_latency" : "1ns",
+            "output_latency" : "1ns",
+            "input_buf_size" : "1KB",
+            "output_buf_size" : "1KB",
+            "flit_size" : "8B",
+            "num_ports" : self.num_ports(x,y),
+        })
+        topo = router.setSubComponent("topology", "merlin.mesh")
+        topo.addParams({
+            "shape" : f"{X}x{Y}",
+            "width" : "1",
+            "local_ports" : "2",
+        })
+        core_if, core_port, core_latency = self.core.build(x, y)
+        link = sst.Link(f"link_core_router_{x}_{y}")
+        link.connect((core_if, core_port, core_latency), (router, self.core_port(), "1ns"))
+
+        mem_if, mem_port, mem_latency = self.memory.build(x, y)
+        link = sst.Link(f"link_router_memory_{x}_{y}")
+        link.connect((router, self.memory_port(), "1ns"), (mem_if, mem_port, mem_latency))
+        return self.ports(x, y, router)
+        
+tile = Tile()
+nodes = {}
+for (x,y) in itertools.product(range(X), range(Y)):
+    nodes[(x,y)] = tile.build(x, y)
+
+link_00_10 = sst.Link("link_00_10")
+link_00_01 = sst.Link("link_00_01")
+link_01_11 = sst.Link("link_01_11")
+link_10_11 = sst.Link("link_10_11")
+
+link_00_01.connect(nodes[(0,0)][NORTH], nodes[(0,1)][SOUTH])
+link_00_10.connect(nodes[(0,0)][EAST],  nodes[(1,0)][WEST])
+link_01_11.connect(nodes[(0,1)][EAST],  nodes[(1,1)][WEST])
+link_10_11.connect(nodes[(1,0)][NORTH], nodes[(1,1)][SOUTH])
+

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -1,5 +1,5 @@
 from compute import XCoreBuilder, RCoreBuilder, ComputeBuilder
-from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder, CachedDRAMBuilder
+from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder, CachedDRAMBuilder, NoCacheDRAMBuilder
 from pod import PodBuilder
 from pxn import PXNBuilder
 from system import SystemBuilder

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -1,0 +1,86 @@
+from compute import XCoreBuilder, RCoreBuilder, ComputeBuilder
+from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder
+from pod import PodBuilder
+from pxn import PXNBuilder
+from system import SystemBuilder
+
+class PANDOHammer(object):
+    """
+    A PANDOHammer Simulation
+    """
+    def __init__(self, arguments, core_builder=XCoreBuilder):
+        """
+        Initialize the PANDOHammer Simulation
+        arguments are parsed from the command line
+        """
+        # l1sp
+        l1sp = L1SPBuilder()
+        l1sp.clock = "1GHz"
+        l1sp.access_time = "1ns"
+        l1sp.size = arguments.core_l1sp_size
+        
+        # core
+        core = core_builder()
+        core.clock = "1GHz"
+        core.threads = arguments.core_threads
+        core.executable = arguments.program
+        core.argv = ' '.join(arguments.argv)
+        core.threads = arguments.core_threads
+        
+        # compute tile
+        compute = ComputeBuilder()
+        compute.l1sp = l1sp
+        compute.core = core
+        
+        # l2sp tile
+        l2sp = L2SPBuilder()
+        l2sp.clock = "1GHz"
+        l2sp.access_time = "10ns"
+        
+        # pod
+        pod = PodBuilder()
+        pod.compute = compute
+        pod.l2sp = l2sp
+        pod.cores = arguments.pod_cores
+        pod.l2sp_size = arguments.pod_l2sp_size
+        pod.l2sp_banks = arguments.pod_l2sp_banks
+        pod.l2sp_interleave = arguments.pod_l2sp_interleave
+    
+        # host core
+        hostcore = XCoreBuilder()
+        hostcore.clock = "1GHz"
+        hostcore.threads = 1
+        hostcore.executable = arguments.with_command_processor
+        hostcore.argv = ' '.join([arguments.program] + arguments.argv)
+        
+        # dram
+        dram = DRAMBuilder()
+        dram.backend = "simple"
+        dram.clock = "1GHz"
+        dram.access_time = "100ns"
+        
+        # pxn
+        pxn = PXNBuilder()
+        pxn.pod = pod
+        pxn.pods = arguments.pxn_pods
+        pxn.hostcore_present = bool(arguments.with_command_processor)
+        pxn.hostcore = hostcore
+        pxn.dram = dram
+        pxn.dram_size = arguments.pxn_dram_size
+        pxn.dram_banks = arguments.pxn_dram_banks
+        pxn.dram_interleave = arguments.pxn_dram_interleave
+        
+        # system
+        system = SystemBuilder()
+        system.pxn = pxn
+        system.pxns = arguments.num_pxn
+        self.system = system
+
+        return
+
+    def build(self):
+        """
+        Build the PANDOHammer Simulation
+        """
+        return self.system.build()
+

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -45,7 +45,7 @@ class PANDOHammer(object):
         l2sp = L2SPBuilder()
         l2sp.clock = "1GHz"
         l2sp.access_time = "1ns"
-        l2sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+        l2sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
 
         # pod
         pod = PodBuilder()

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -1,5 +1,5 @@
 from compute import XCoreBuilder, RCoreBuilder, ComputeBuilder
-from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder
+from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder, CachedDRAMBuilder
 from pod import PodBuilder
 from pxn import PXNBuilder
 from system import SystemBuilder
@@ -13,11 +13,16 @@ class PANDOHammer(object):
         Initialize the PANDOHammer Simulation
         arguments are parsed from the command line
         """
+        bandwidth_bytes_per_second_per_core = 24e9
+        bandwidth_bytes_per_second_per_pod = bandwidth_bytes_per_second_per_core*arguments.pod_cores
+        bandwidth_bytes_per_second_per_pxn = bandwidth_bytes_per_second_per_pod*arguments.pxn_pods
+
         # l1sp
         l1sp = L1SPBuilder()
         l1sp.clock = "1GHz"
         l1sp.access_time = "1ns"
         l1sp.size = arguments.core_l1sp_size
+        l1sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
         
         # core
         core = core_builder()
@@ -26,17 +31,22 @@ class PANDOHammer(object):
         core.executable = arguments.program
         core.argv = ' '.join(arguments.argv)
         core.threads = arguments.core_threads
+        core.network_bw = "24GB/s"
         
         # compute tile
         compute = ComputeBuilder()
         compute.l1sp = l1sp
         compute.core = core
+        compute.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        compute.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        compute.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
         
         # l2sp tile
         l2sp = L2SPBuilder()
         l2sp.clock = "1GHz"
-        l2sp.access_time = "10ns"
-        
+        l2sp.access_time = "1ns"
+        l2sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+
         # pod
         pod = PodBuilder()
         pod.compute = compute
@@ -45,7 +55,10 @@ class PANDOHammer(object):
         pod.l2sp_size = arguments.pod_l2sp_size
         pod.l2sp_banks = arguments.pod_l2sp_banks
         pod.l2sp_interleave = arguments.pod_l2sp_interleave
-    
+        pod.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+        pod.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+        pod.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+
         # host core
         hostcore = XCoreBuilder()
         hostcore.clock = "1GHz"
@@ -54,11 +67,16 @@ class PANDOHammer(object):
         hostcore.argv = ' '.join([arguments.program] + arguments.argv)
         
         # dram
-        dram = DRAMBuilder()
+        if arguments.without_pxn_dram_cache:
+            dram = NoCacheDRAMBuilder()
+        else:
+            dram = CachedDRAMBuilder()
+
         dram.backend = "simple"
         dram.clock = "1GHz"
-        dram.access_time = "100ns"
-        
+        dram.access_time = arguments.dram_access_time
+        dram.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+
         # pxn
         pxn = PXNBuilder()
         pxn.pod = pod
@@ -69,7 +87,10 @@ class PANDOHammer(object):
         pxn.dram_size = arguments.pxn_dram_size
         pxn.dram_banks = arguments.pxn_dram_banks
         pxn.dram_interleave = arguments.pxn_dram_interleave
-        
+        pxn.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+        pxn.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+        pxn.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+
         # system
         system = SystemBuilder()
         system.pxn = pxn

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -66,6 +66,7 @@ class PANDOHammer(object):
         hostcore.executable = arguments.with_command_processor
         hostcore.argv = ' '.join([arguments.program] + arguments.argv)
         hostcore.group = "0"
+        hostcore.is_host = True
 
         # dram
         if arguments.without_pxn_dram_cache:

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -65,7 +65,8 @@ class PANDOHammer(object):
         hostcore.threads = 1
         hostcore.executable = arguments.with_command_processor
         hostcore.argv = ' '.join([arguments.program] + arguments.argv)
-        
+        hostcore.group = "0"
+
         # dram
         if arguments.without_pxn_dram_cache:
             dram = NoCacheDRAMBuilder()

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -31,7 +31,7 @@ class PANDOHammer(object):
         core.executable = arguments.program
         core.argv = ' '.join(arguments.argv)
         core.threads = arguments.core_threads
-        core.network_bw = "24GB/s"
+        core.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
         
         # compute tile
         compute = ComputeBuilder()

--- a/model/pandohammer.py
+++ b/model/pandohammer.py
@@ -22,7 +22,7 @@ class PANDOHammer(object):
         l1sp.clock = "1GHz"
         l1sp.access_time = "1ns"
         l1sp.size = arguments.core_l1sp_size
-        l1sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        l1sp.network_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
         
         # core
         core = core_builder()
@@ -31,21 +31,21 @@ class PANDOHammer(object):
         core.executable = arguments.program
         core.argv = ' '.join(arguments.argv)
         core.threads = arguments.core_threads
-        core.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        core.network_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
         
         # compute tile
         compute = ComputeBuilder()
         compute.l1sp = l1sp
         compute.core = core
-        compute.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
-        compute.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
-        compute.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        compute.network_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
+        compute.xbar_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
+        compute.link_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
         
         # l2sp tile
         l2sp = L2SPBuilder()
         l2sp.clock = "1GHz"
         l2sp.access_time = "1ns"
-        l2sp.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_core)
+        l2sp.network_bw = f"{bandwidth_bytes_per_second_per_core}B/s"
 
         # pod
         pod = PodBuilder()
@@ -55,9 +55,9 @@ class PANDOHammer(object):
         pod.l2sp_size = arguments.pod_l2sp_size
         pod.l2sp_banks = arguments.pod_l2sp_banks
         pod.l2sp_interleave = arguments.pod_l2sp_interleave
-        pod.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
-        pod.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
-        pod.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pod)
+        pod.network_bw = f"{bandwidth_bytes_per_second_per_pod}B/s"
+        pod.xbar_bw = f"{bandwidth_bytes_per_second_per_pod}B/s"
+        pod.link_bw = f"{bandwidth_bytes_per_second_per_pod}B/s"
 
         # host core
         hostcore = XCoreBuilder()
@@ -77,7 +77,7 @@ class PANDOHammer(object):
         dram.backend = "simple"
         dram.clock = "1GHz"
         dram.access_time = arguments.dram_access_time
-        dram.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+        dram.network_bw = f"{bandwidth_bytes_per_second_per_pxn}B/s"
 
         # pxn
         pxn = PXNBuilder()
@@ -89,9 +89,9 @@ class PANDOHammer(object):
         pxn.dram_size = arguments.pxn_dram_size
         pxn.dram_banks = arguments.pxn_dram_banks
         pxn.dram_interleave = arguments.pxn_dram_interleave
-        pxn.network_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
-        pxn.xbar_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
-        pxn.link_bw = "{}B/s".format(bandwidth_bytes_per_second_per_pxn)
+        pxn.network_bw = f"{bandwidth_bytes_per_second_per_pxn}B/s"
+        pxn.xbar_bw = f"{bandwidth_bytes_per_second_per_pxn}B/s"
+        pxn.link_bw = f"{bandwidth_bytes_per_second_per_pxn}B/s"
 
         # system
         system = SystemBuilder()

--- a/model/pod.py
+++ b/model/pod.py
@@ -1,0 +1,163 @@
+import sst
+from compute import ComputeBuilder, XCoreBuilder
+from memory import L2SPBuilder, DRAMBuilder
+
+    
+class Pod(object):
+    """
+    A base class for a pod
+    """
+    def __init__(self, name):
+        """
+        Initialize the pod
+        """
+        self.name = ""
+        self.cores = []
+        self.l2sp_banks = []
+        self.bridge = None
+        self.id = 0
+        return
+    
+    def network_interface(self):
+        """
+        Returns the network interface subcomponent and port name
+        (interface, portname) pair
+        """
+        return (self.bridge, "network1")
+
+class PodBuilder(object):
+    """
+    A base class for a pod builder
+    """
+    def __init__(self):
+        """
+        Initialize the pod builder
+        """
+        self.compute = ComputeBuilder()
+        self.l2sp_size = 1024*1024
+        self.l2sp_banks = 1
+        self._l2sp_interleave = self.l2sp_size//self.l2sp_banks
+        self.l2sp = L2SPBuilder()
+        self.xbar_bw = "1GB/s"
+        self.link_bw = "1GB/s"
+        self.input_buf_size = "1KB"
+        self.output_buf_size = "1KB"
+        self.router_latency = "1ns"
+        self.network_bw = "1GB/s"
+        return
+
+    @property
+    def l2sp_bank_size(self):
+        return self.l2sp_size // self.l2sp_banks
+
+    @property
+    def l2sp_interleave(self):
+        if self._l2sp_interleave == 0:
+            return self.l2sp_bank_size
+        return self._l2sp_interleave
+
+    @l2sp_interleave.setter
+    def l2sp_interleave(self, value):
+        self._l2sp_interleave = value
+        return
+
+    @property
+    def l2sp_interleave_step(self):
+        return self.l2sp_interleave * self.l2sp_banks
+    
+    def router_name(self, name):
+        """
+        Returns the router name
+        """
+        return "{}_router".format(name)
+
+    def core_name(self, name, core_id):
+        """
+        Returns the core name
+        """
+        return "{}_core{}".format(name, core_id)
+
+    def l2sp_name(self, name, bank_id):
+        """
+        Returns the L2SP name
+        """
+        return "{}_l2sp{}".format(name, bank_id)
+
+    def bridge_name(self, name):
+        """
+        Returns the bridge name
+        """
+        return "{}_bridge".format(name)
+
+    def ports(self):
+        """
+        Returns the number of ports
+        """
+        # cores + l2sp banks + on-chip network
+        return self.cores + self.l2sp_banks + 1
+
+    def build(self, system_builder, name):
+        pod = Pod(name)
+
+        # build the router
+        pod.network = sst.Component(self.router_name(name), "merlin.hr_router")
+        pod.network.addParams({
+            "id" : 0,
+            "num_ports" : self.ports(),
+            "topology" : "merlin.singlerouter",
+            # performance models
+            "xbar_bw" : self.xbar_bw,
+            "link_bw" : self.link_bw,
+            "flit_size" : "8B",
+            "input_buf_size" : self.input_buf_size,
+            "output_buf_size" : self.output_buf_size,
+            "input_latency" : self.router_latency,
+            "output_latency" : self.router_latency
+        })
+        pod.network.setSubComponent("topology", "merlin.singlerouter")
+        current_port = 0
+
+        # build the cores
+        for core_id in range(self.cores):
+            self.compute.id = core_id
+            # core is a full compute tile in this context
+            core = self.compute.build(system_builder, self.core_name(name, core_id))
+            nwif, port = core.network_interface()
+            link = sst.Link("link_{}_{}".format(core.name, self.router_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (pod.network, "port{}".format(current_port), "1ns")
+            )
+            current_port += 1        
+            pod.cores.append(core)
+                    
+        # build the l2sp banks
+        self.l2sp.size = self.l2sp_bank_size
+        self.l2sp.interleave_size = self.l2sp_interleave
+        self.l2sp.interleave_step = self.l2sp_interleave_step        
+        for bank_id in range(self.l2sp_banks):
+            self.l2sp.id = bank_id
+            l2sp = self.l2sp.build(system_builder, self.l2sp_name(name, bank_id))
+            nwif, port = l2sp.network_interface()
+            link = sst.Link("link_{}_{}".format(l2sp.name, self.router_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (pod.network, "port{}".format(current_port), "1ns")
+            )
+            pod.l2sp_banks.append(l2sp)
+            current_port += 1
+        
+        # build the bridge
+        pod.bridge = sst.Component(self.bridge_name(name), "merlin.Bridge")
+        pod.bridge.addParams({
+            "translator" : "memHierarchy.MemNetBridge",
+            "network_bw" : self.network_bw
+        })
+        
+        link = sst.Link("link_{}_{}".format(self.router_name(name), self.bridge_name(name)))
+        link.connect(
+            (pod.network, "port{}".format(current_port), "1ns"),
+            (pod.bridge, "network0", "1ns")
+        )
+
+        return pod

--- a/model/pod.py
+++ b/model/pod.py
@@ -69,25 +69,25 @@ class PodBuilder(object):
         """
         Returns the router name
         """
-        return "{}_router".format(name)
+        return f"{name}_router"
 
     def core_name(self, name, core_id):
         """
         Returns the core name
         """
-        return "{}_core{}".format(name, core_id)
+        return f"{name}_core{core_id}"
 
     def l2sp_name(self, name, bank_id):
         """
         Returns the L2SP name
         """
-        return "{}_l2sp{}".format(name, bank_id)
+        return f"{name}_l2sp{bank_id}"
 
     def bridge_name(self, name):
         """
         Returns the bridge name
         """
-        return "{}_bridge".format(name)
+        return f"{name}_bridge"
 
     def ports(self):
         """
@@ -123,10 +123,10 @@ class PodBuilder(object):
             # core is a full compute tile in this context
             core = self.compute.build(system_builder, self.core_name(name, core_id))
             nwif, port = core.network_interface()
-            link = sst.Link("link_{}_{}".format(core.name, self.router_name(name)))
+            link = sst.Link(f"link_{core.name}_{self.router_name(name)}")
             link.connect(
                 (nwif, port, "1ns"),
-                (pod.network, "port{}".format(current_port), "1ns")
+                (pod.network, f"port{current_port}", "1ns")
             )
             current_port += 1        
             pod.cores.append(core)
@@ -139,10 +139,10 @@ class PodBuilder(object):
             self.l2sp.id = bank_id
             l2sp = self.l2sp.build(system_builder, self.l2sp_name(name, bank_id))
             nwif, port = l2sp.network_interface()
-            link = sst.Link("link_{}_{}".format(l2sp.name, self.router_name(name)))
+            link = sst.Link(f"link_{l2sp.name}_{self.router_name(name)}")
             link.connect(
                 (nwif, port, "1ns"),
-                (pod.network, "port{}".format(current_port), "1ns")
+                (pod.network, f"port{current_port}", "1ns")
             )
             pod.l2sp_banks.append(l2sp)
             current_port += 1
@@ -154,9 +154,9 @@ class PodBuilder(object):
             "network_bw" : self.network_bw
         })
         
-        link = sst.Link("link_{}_{}".format(self.router_name(name), self.bridge_name(name)))
+        link = sst.Link(f"link_{self.router_name(name)}_{self.bridge_name(name)}")
         link.connect(
-            (pod.network, "port{}".format(current_port), "1ns"),
+            (pod.network, f"port{current_port}", "1ns"),
             (pod.bridge, "network0", "1ns")
         )
 

--- a/model/pod.py
+++ b/model/pod.py
@@ -11,7 +11,7 @@ class Pod(object):
         """
         Initialize the pod
         """
-        self.name = ""
+        self.name = name
         self.cores = []
         self.l2sp_banks = []
         self.bridge = None
@@ -42,7 +42,7 @@ class PodBuilder(object):
         self.link_bw = "1GB/s"
         self.input_buf_size = "1KB"
         self.output_buf_size = "1KB"
-        self.router_latency = "1ns"
+        self.router_latency = "0ns"
         self.network_bw = "1GB/s"
         return
 

--- a/model/pxn.py
+++ b/model/pxn.py
@@ -64,7 +64,11 @@ class PXNBuilder(object):
     def dram_interleave(self, value):
         self._dram_interleave = value
         return
-    
+
+    @property
+    def dram_interleave_step(self):
+        return self.dram_interleave * self.dram_banks
+
     def router_name(self, name):
         """
         Get the router name
@@ -143,6 +147,9 @@ class PXNBuilder(object):
             current_port += 1
 
         # build the dram banks
+        self.dram.size = self.dram_size
+        self.dram.interleave_size = self.dram_interleave
+        self.dram.interleave_step = self.dram_interleave_step
         for dram_bank_id in range(self.dram_banks):
             self.dram.id = dram_bank_id
             dram = self.dram.build(system_builder, self.dram_bank_name(name, dram_bank_id))

--- a/model/pxn.py
+++ b/model/pxn.py
@@ -79,7 +79,7 @@ class PXNBuilder(object):
         """
         Get the pod name
         """
-        return name + "_pod{}".format(pod_id)
+        return name + f"_pod{pod_id}"
 
     def hostcore_name(self, name):
         """
@@ -91,7 +91,7 @@ class PXNBuilder(object):
         """
         Get the dram bank name
         """
-        return name + "_dram{}".format(bank_id)
+        return name + f"_dram{bank_id}"
 
     def bridge_name(self, name):
         """
@@ -138,10 +138,10 @@ class PXNBuilder(object):
             self.pod.id = pod_id
             pod = self.pod.build(system_builder, self.pod_name(name, pod_id))
             nwif, port = pod.network_interface()
-            link = sst.Link("{}_to_{}".format(pod.name, self.router_name(name)))
+            link = sst.Link(f"{pod.name}_to_{self.router_name(name)}")                            
             link.connect(
                 (nwif, port, "1ns"),
-                (pxn.network, "port{}".format(current_port), "1ns")
+                (pxn.network, f"port{current_port}", "1ns")
             )
             pxn.pods.append(pod)
             current_port += 1
@@ -154,10 +154,10 @@ class PXNBuilder(object):
             self.dram.id = dram_bank_id
             dram = self.dram.build(system_builder, self.dram_bank_name(name, dram_bank_id))
             nwif, port = dram.network_interface()
-            link = sst.Link("{}_to_{}".format(dram.name, self.router_name(name)))
+            link = sst.Link(f"{dram.name}_to_{self.router_name(name)}")
             link.connect(
                 (nwif, port, "1ns"),
-                (pxn.network, "port{}".format(current_port), "1ns")
+                (pxn.network, f"port{current_port}", "1ns")
             )
             pxn.dram_banks.append(dram)
             current_port += 1
@@ -167,10 +167,10 @@ class PXNBuilder(object):
             self.hostcore.id = -1
             hostcore = self.hostcore.build(system_builder, self.hostcore_name(name))
             nwif, port = hostcore.network_interface()
-            link = sst.Link("{}_to_{}".format(hostcore.name, self.router_name(name)))
+            link = sst.Link(f"{hostcore.name}_to_{self.router_name(name)}")
             link.connect(
                 (nwif, port, "1ns"),
-                (pxn.network, "port{}".format(current_port), "1ns")
+                (pxn.network, f"port{current_port}", "1ns")
             )
             pxn.hostcore = hostcore
             current_port += 1
@@ -181,9 +181,9 @@ class PXNBuilder(object):
             "translator" : "memHierarchy.MemNetBridge",
             "network_bw" : self.network_bw,
         })
-        link = sst.Link("{}_to_{}".format(self.router_name(name), self.bridge_name(name)))
+        link = sst.Link(f"{self.router_name(name)}_to_{self.bridge_name(name)}")
         link.connect(
-            (pxn.network, "port{}".format(current_port), "1ns"),
+            (pxn.network, f"port{current_port}", "1ns"),
             (bridge, "network0", "1ns")
         )        
         pxn.bridge = bridge

--- a/model/pxn.py
+++ b/model/pxn.py
@@ -42,7 +42,7 @@ class PXNBuilder(object):
         self.pods = 1
         self.hostcore = XCoreBuilder()
         self.hostcore_present = True
-        self.dram = DRAMBuilder()
+        self.dram = CachedDRAMBuilder()
         self.dram_size = 2*1024*1024
         self.dram_banks = 1
         self._dram_interleave = 0
@@ -51,7 +51,7 @@ class PXNBuilder(object):
         self.network_bw = "1GB/s"
         self.input_buf_size = "1KB"
         self.output_buf_size = "1KB"
-        self.router_latency = "1ns"
+        self.router_latency = "0ns"
         return
 
     @property

--- a/model/pxn.py
+++ b/model/pxn.py
@@ -1,0 +1,183 @@
+from pod import *
+from compute import *
+from memory import *
+import sst
+
+class PXN(object):
+    """
+    A base class for a pxn
+
+    A pxn has an endpoint in the on-chip network.
+    It provides the network_if() method to get the network interface
+    """
+    def __init__(self, name):
+        """
+        Initialize the pxn
+        """
+        self.pods = []
+        self.dram_banks = []
+        self.hostcore = None
+        self.network = None
+        self.bridge = None
+        self.name = name
+        return
+
+    def network_interface(self):
+        """
+        Returns the network interface subcomponent and port name
+        (interface, portname) pair
+        """
+        return (self.bridge, "network1")
+
+class PXNBuilder(object):
+    """
+    A base class for a pxn builder
+    """
+    def __init__(self):
+        """
+        Initialize the pxn builder
+        """
+        self.id = 0
+        self.pod = PodBuilder()
+        self.pods = 1
+        self.hostcore = XCoreBuilder()
+        self.hostcore_present = True
+        self.dram = DRAMBuilder()
+        self.dram_size = 2*1024*1024
+        self.dram_banks = 1
+        self._dram_interleave = 0
+        self.xbar_bw = "1GB/s"        
+        self.link_bw = "1GB/s"
+        self.network_bw = "1GB/s"
+        self.input_buf_size = "1KB"
+        self.output_buf_size = "1KB"
+        self.router_latency = "1ns"
+        return
+
+    @property
+    def dram_interleave(self):
+        if self._dram_interleave == 0:
+            return self.dram_size // self.dram_banks
+        return self._dram_interleave
+
+    @dram_interleave.setter
+    def dram_interleave(self, value):
+        self._dram_interleave = value
+        return
+    
+    def router_name(self, name):
+        """
+        Get the router name
+        """
+        return name + "_router"
+
+    def pod_name(self, name, pod_id):
+        """
+        Get the pod name
+        """
+        return name + "_pod{}".format(pod_id)
+
+    def hostcore_name(self, name):
+        """
+        Get the hostcore name
+        """
+        return name + "_hostcore"
+
+    def dram_bank_name(self, name, bank_id):
+        """
+        Get the dram bank name
+        """
+        return name + "_dram{}".format(bank_id)
+
+    def bridge_name(self, name):
+        """
+        Get the bridge name
+        """
+        return name + "_bridge"
+
+    def ports(self):
+        """
+        Get the number of ports
+        """
+        # pods + dram banks + off-chip network + hostcore
+        return self.pods \
+            + self.dram_banks \
+            + 1 \
+            + (1 if self.hostcore_present else 0)
+    
+    def build(self, system_builder, name):
+        """
+        Make a pxn
+        """
+        pxn = PXN(name)
+        # build the interpod network
+        pxn.network = sst.Component(self.router_name(name), "merlin.hr_router")
+        pxn.network.addParams({
+            # semantic parameters
+            "id" : 0,
+            "num_ports" : self.ports(),
+            "topology" : "merlin.singlerouter",            
+            # performance models
+            "xbar_bw" : self.xbar_bw,
+            "link_bw" : self.link_bw,
+            "flit_size" : "8B",
+            "input_buf_size" : self.input_buf_size,
+            "output_buf_size" : self.output_buf_size,
+            "input_latency" : self.router_latency,
+            "output_latency" : self.router_latency,
+        })
+        pxn.network.setSubComponent("topology", "merlin.singlerouter")
+
+        # build the pods
+        current_port = 0        
+        for pod_id in range(self.pods):
+            self.pod.id = pod_id
+            pod = self.pod.build(system_builder, self.pod_name(name, pod_id))
+            nwif, port = pod.network_interface()
+            link = sst.Link("{}_to_{}".format(pod.name, self.router_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (pxn.network, "port{}".format(current_port), "1ns")
+            )
+            pxn.pods.append(pod)
+            current_port += 1
+
+        # build the dram banks
+        for dram_bank_id in range(self.dram_banks):
+            self.dram.id = dram_bank_id
+            dram = self.dram.build(system_builder, self.dram_bank_name(name, dram_bank_id))
+            nwif, port = dram.network_interface()
+            link = sst.Link("{}_to_{}".format(dram.name, self.router_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (pxn.network, "port{}".format(current_port), "1ns")
+            )
+            pxn.dram_banks.append(dram)
+            current_port += 1
+
+        # build the hostcore
+        if self.hostcore_present:
+            self.hostcore.id = -1
+            hostcore = self.hostcore.build(system_builder, self.hostcore_name(name))
+            nwif, port = hostcore.network_interface()
+            link = sst.Link("{}_to_{}".format(hostcore.name, self.router_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (pxn.network, "port{}".format(current_port), "1ns")
+            )
+            pxn.hostcore = hostcore
+            current_port += 1
+
+        # create the network bridge to the off-chip network
+        bridge = sst.Component(self.bridge_name(name), "merlin.Bridge")
+        bridge.addParams({
+            "translator" : "memHierarchy.MemNetBridge",
+            "network_bw" : self.network_bw,
+        })
+        link = sst.Link("{}_to_{}".format(self.router_name(name), self.bridge_name(name)))
+        link.connect(
+            (pxn.network, "port{}".format(current_port), "1ns"),
+            (bridge, "network0", "1ns")
+        )        
+        pxn.bridge = bridge
+        return pxn

--- a/model/system.py
+++ b/model/system.py
@@ -1,0 +1,103 @@
+import sst
+from compute import ComputeBuilder, CoreBuilder, XCoreBuilder, RCoreBuilder
+from memory import L1SPBuilder, L2SPBuilder, DRAMBuilder
+from pod import PodBuilder
+from pxn import PXNBuilder
+from addressmap import AddressMap
+
+class System(object):
+    """
+    A system object
+    """
+    def __init__(self, name):
+        """
+        Initialize the system
+        """
+        self.pxns = []
+        self.name = name
+        return
+
+class SystemBuilder(object):
+    """
+    A base class for a system builder
+    """
+    def __init__(self):
+        """
+        Initialize the system builder
+        """
+        self.pxn = PXNBuilder()
+        self.pxns = 1
+        self.xbar_bw = "1GB/s"
+        self.link_bw = "1GB/s"
+        self.input_buf_size = "1KB"
+        self.output_buf_size = "1KB"
+        self.router_latency = "1ns"
+        return
+
+    def addressmap(self):
+        """
+        Get the address map
+        """
+        class sysconfig(object):
+            def __init__(self, system_builder):
+                self.system_builder = system_builder
+            def pxns(self):
+                return self.system_builder.pxns
+            def pods(self):
+                return self.system_builder.pxn.pods
+            def cores(self):
+                return self.system_builder.pxn.pod.cores
+        
+        return AddressMap(sysconfig(self))
+    
+    def network_name(self, name):
+        """
+        Get the network name
+        """
+        return name + "_network"
+
+    def pxn_name(self, name, pxn_id):
+        """
+        Get the PXN name
+        """
+        return name + "_pxn{}".format(pxn_id)
+    
+    def build(self, name = "system"):
+        """
+        Make a system
+        """
+        system = System(name)
+
+        # build the interpxn network
+        system.network = sst.Component(self.network_name(name), "merlin.hr_router")
+        system.network.addParams({
+            # semantic parameters
+            "id" : 0,
+            "num_ports" : self.pxns,
+            "topology" : "merlin.singlerouter",
+            # performance models
+            "xbar_bw" : self.xbar_bw,
+            "link_bw" : self.link_bw,
+            "flit_size" : "8B",
+            "input_buf_size" : self.input_buf_size,
+            "output_buf_size" : self.output_buf_size,
+            "input_latency" : self.router_latency,
+            "output_latency" : self.router_latency,
+        })
+        system.network.setSubComponent("topology", "merlin.singlerouter")
+
+        # build the PXNs
+        for pxn_id in range(self.pxns):
+            self.pxn.id = pxn_id
+            pxn = self.pxn.build(self, self.pxn_name(name, pxn_id))
+            nwif, port = pxn.network_interface()
+            link = sst.Link("{}_to_{}".format(pxn.name, self.network_name(name)))
+            link.connect(
+                (nwif, port, "1ns"),
+                (system.network, "port{}".format(pxn_id), "1ns")
+            )
+            system.pxns.append(pxn)
+
+        return system
+
+    

--- a/model/system.py
+++ b/model/system.py
@@ -60,7 +60,7 @@ class SystemBuilder(object):
         """
         Get the PXN name
         """
-        return name + "_pxn{}".format(pxn_id)
+        return name + f"_pxn{pxn_id}"
     
     def build(self, name = "system"):
         """
@@ -91,10 +91,10 @@ class SystemBuilder(object):
             self.pxn.id = pxn_id
             pxn = self.pxn.build(self, self.pxn_name(name, pxn_id))
             nwif, port = pxn.network_interface()
-            link = sst.Link("{}_to_{}".format(pxn.name, self.network_name(name)))
+            link = sst.Link(f"{pxn.name}_to_{self.network_name(name)}")
             link.connect(
                 (nwif, port, "1ns"),
-                (system.network, "port{}".format(pxn_id), "1ns")
+                (system.network, f"port{pxn_id}", "1ns")
             )
             system.pxns.append(pxn)
 

--- a/pandohammer/crt.S
+++ b/pandohammer/crt.S
@@ -27,6 +27,22 @@ _start:
   li      a0, 0xFFFFFFFFFFFF0008
   li      a1, 0x15eedeadface5
   sw      a1, 0(a0)
+#if 1
+  # set the stack pointer
+  csrr a0, mhartid
+  addi a0, a0, 1
+  csrr a1, MCSR_MCOREHARTS
+  csrr a2, MCSR_L1SPBASE
+  csrr sp, MCSR_MCOREL1SPSIZE
+  srli sp, sp, 3
+  divu sp, sp, a1
+  slli sp, sp, 3
+  mul  sp, sp, a0
+  add  sp, sp, a2
+  addi sp, sp, -8
+  li a0, 0xFFFFFFFFFFFF0008
+  sw sp, 0(a0)
+#endif
   # Skip if not thread 0
   csrr a0, mhartid
   csrr a1, MCSR_MCOREID
@@ -48,7 +64,6 @@ _start:
   beqz    a0, .Lweak_atexit
   .weak   __libc_fini_array
 #endif
-
   la      a0, __libc_fini_array   # Register global termination functions
   call    atexit                  #  to be called upon exit
 #ifdef _LITE_EXIT

--- a/pandohammer/pandohammer/register.h
+++ b/pandohammer/pandohammer/register.h
@@ -1,7 +1,9 @@
 #ifndef PANDOHAMMER_REGISTER_H
 #define PANDOHAMMER_REGISTER_H
 
-#define MCSR_SLEEP 0x7A5
+#define MCSR_SLEEP     0x7A5
+#define MCSR_L1SPBASE  0x7A6
+
 #define MCSR_MCOREID    0xF15
 #define MCSR_MPODID     0xF16
 #define MCSR_MPXNID     0xF17

--- a/py/addressmap.py
+++ b/py/addressmap.py
@@ -467,6 +467,28 @@ class AddressRangeBuilder(object):
         """
         return (self._address_map.encode(start_info), self._address_map.encode(stop_info), self._interleave_size, self._interleave_step)
 
+class CoreCtrlAddressBuilder(AddressRangeBuilder):
+    def __init__(self, address_map, memsize):
+        """
+        @brief constructor
+        @param address_map: the address map
+        @param memsize: the size of the memory
+        """
+        super().__init__(address_map, memsize)
+
+    def __call__(self, pxn, pod, core):
+        """
+        @brief build an address range for a core control memory
+        @param pxn: the pxn
+        @param pod: the pod
+        @param core: the core
+        @return (first byte, last byte)
+        """
+        start_info, stop_info = self.interleaved_address_range(0)
+        start_info.set_core_ctrl().set_pxn(pxn).set_pod(pod).set_core(core)
+        stop_info.set_core_ctrl().set_pxn(pxn).set_pod(pod).set_core(core)
+        return self.call_outputs(start_info, stop_info)
+
 class L1SPAddressBuilder(AddressRangeBuilder):
     def __init__(self, address_map, memsize):
         """


### PR DESCRIPTION
* disassemble targets
* compile options
* refactored modeling scripts in `drv/model`
* riscv threads can now set their own stack pointers (no longer needs the script to do it).
* stride benchmark in drvx
* example model of a mesh network