### PR TITLE
Update Makefile with missing API header

### DIFF
--- a/api/DrvAPI.hpp
+++ b/api/DrvAPI.hpp
@@ -18,5 +18,6 @@
 #include <DrvAPIAddressMap.hpp>
 #include <DrvAPIAddressToNative.hpp>
 #include <DrvAPINativeToAddress.hpp>
+#include <DrvAPISection.hpp>
 #include <DrvAPISystem.hpp>
 #endif

--- a/api/Makefile
+++ b/api/Makefile
@@ -44,6 +44,7 @@ libdrvapi-headers += $(DRV_DIR)/api/DrvAPICoreXY.hpp
 libdrvapi-headers += $(DRV_DIR)/api/DrvAPIAddressToNative.hpp
 libdrvapi-headers += $(DRV_DIR)/api/DrvAPINativeToAddress.hpp
 libdrvapi-headers += $(DRV_DIR)/api/DrvAPISystem.hpp
+libdrvapi-headers += $(DRV_DIR)/api/DrvAPISection.hpp
 libdrvapi-headers += $(DRV_DIR)/api/DrvAPI.hpp
 libdrvapi-install-headers := $(foreach header,$(libdrvapi-headers),$(DRV_INCLUDE_DIR)/$(notdir $(header)))
 


### PR DESCRIPTION
This happened on `make install` after running through all the steps in the README.md without docker.